### PR TITLE
docs: update version requirements to reflect current dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ If you want to run this service without a Docker container, you have to build it
 
 Prerequisites:
 
-- Go 1.24+
-- Node.js v16+
+- Go 1.25+
+- Node.js 24+
 - Corepack (`npm i -g corepack`)
 
 You can configure this via a `.env.local` file or via command options (for more information you can run `./ldap-selfservice-password-changer --help`).
@@ -95,8 +95,8 @@ docker run \
 
 Prerequisites:
 
-- Go 1.24+
-- Node.js v16+
+- Go 1.25+
+- Node.js 24+
 - Corepack (`npm i -g corepack`)
 
 ```bash

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -4,9 +4,9 @@
 
 ### Required Tools
 
-- **Go**: 1.24.0+ (tested with 1.25.1)
-- **Node.js**: v16+ (tested with v22)
-- **pnpm**: 10.17.1+ (installed via Corepack)
+- **Go**: 1.25.0+ (tested with 1.25.1)
+- **Node.js**: 24+ (tested with 24)
+- **pnpm**: 10.18.0+ (installed via Corepack)
 - **Git**: For version control
 
 ### System Requirements
@@ -30,7 +30,7 @@ cd ldap-selfservice-password-changer
 corepack enable
 ```
 
-This ensures pnpm version matches package.json specification (10.17.1).
+This ensures pnpm version matches package.json specification (10.18.0).
 
 ### 3. Install Dependencies
 


### PR DESCRIPTION
## Summary
Updates version requirements in documentation to match the current dependency versions after comprehensive upgrade.

## Changes
### README.md
- Go: 1.24+ → 1.25+ (2 occurrences in Prerequisites sections)
- Node.js: v16+ → 24+ (2 occurrences in Prerequisites sections)

### docs/development-guide.md
- Go: 1.24.0+ → 1.25.0+ (tested with 1.25.1)
- Node.js: v16+ → 24+ (tested with 24)
- pnpm: 10.17.1+ → 10.18.0+ (installed via Corepack)
- Updated inline reference to pnpm specification (10.17.1 → 10.18.0)

## Verification
All version requirements now match actual project configuration:
- ✅ go.mod: `go 1.25`
- ✅ Dockerfile: `node:24@sha256:...`
- ✅ GitHub Actions: `node-version: "24"`
- ✅ package.json: `"packageManager": "pnpm@10.18.0"`

## Context
These updates align documentation with the comprehensive dependency upgrade completed in PR #262 and PR #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>