### PR TITLE
ci(docker): use reusable build-container workflow + backfill trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,78 +1,28 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
   schedule:
     - cron: "0 0 * * 0"
   pull_request:
   push:
     branches:
       - main
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: "${{ github.repository_owner }}/ldap-selfservice-password-changer"
-
-permissions:
-  contents: read
-  packages: write
-  security-events: write
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v1.3.0). Leave empty to build the current ref."
+        required: false
+        type: string
 
 jobs:
-  docker:
-    name: Build Images
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Gather Docker metadata
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{version}}.{{major}}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
-          scanners: "vuln,config,secret"
-
-      - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        if: always()
-        with:
-          sarif_file: "trivy-results.sarif"
-          category: "container-scan"
+  build:
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: ldap-selfservice-password-changer
+      ref: ${{ inputs.tag || '' }}


### PR DESCRIPTION
## Summary

- Replaces the bespoke 79-line `docker.yml` with a 28-line caller of [netresearch/.github#20](https://github.com/netresearch/.github/pull/20)'s reusable `build-container.yml`.
- Fixes the **missing v1.3.0 container image**: GoReleaser creates releases using `GITHUB_TOKEN`, which does **not** fire the `release: published` event downstream (GitHub blocks `GITHUB_TOKEN`-created events from triggering other workflows). So the previous `on: release` trigger never ran for tagged releases — v1.3.0 was only ever built with a `main` tag.
- Triggers are now: push to `main`, push of `v*` tag, pull_request, weekly cron, and **`workflow_dispatch` with a `tag` input** so any tag can be (re)built manually without re-tagging.
- Also fixes the bogus `{{version}}.{{major}}` tag pattern (would produce `1.3.0.1`) — reusable workflow uses correct `{{major}}.{{minor}}` + `{{major}}`.

## Backfill plan (after merge)

```bash
gh workflow run docker.yml --ref main -f tag=v1.3.0
```

This should produce multi-arch `ghcr.io/netresearch/ldap-selfservice-password-changer:{1.3.0, 1.3, 1}`.

## Test plan

- [ ] CI green on this PR (pull_request trigger runs the reusable workflow with `push: true`, producing a `pr-<N>` image tag — validates the wiring).
- [ ] After merge, `workflow_dispatch` with `tag: v1.3.0` succeeds and publishes `ghcr.io/netresearch/ldap-selfservice-password-changer:1.3.0`.