### PR TITLE
fix(docker): grant id-token/attestations at caller

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,5 +22,7 @@ jobs:
       contents: read
       packages: write
       security-events: write
+      id-token: write
+      attestations: write
     with:
       image-name: ldap-selfservice-password-changer


### PR DESCRIPTION
Post-merge Docker runs on main have been hitting \`startup_failure\` after \`build-container.yml@main\` was enhanced with \`id-token/attestations\` permissions at workflow level (for the sign/attest features in #23).

Root cause: when a reusable workflow declares permissions the caller hasn't granted, GitHub fails the run at startup for certain trigger contexts (notably merge-queue and subsequent pushes) before any job runs. The caller must grant at least the union of what the reusable declares at workflow level.

Grants \`id-token: write\` and \`attestations: write\` at the job level. Also adds \`workflow_dispatch\` so the workflow can be manually dispatched post-merge to verify.

After this PR merges, I'll apply the same fix to \`netresearch/ldap-manager\` and \`netresearch/raybeam\`.