### PR TITLE
chore(agents): refresh AGENTS.md (thin root, pnpm→bun, add Security)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@
 
 ## Index of scoped AGENTS.md
 
-| Path                                             | Scope                                               |
-| ------------------------------------------------ | --------------------------------------------------- |
-| [internal/AGENTS.md](./internal/AGENTS.md)       | Go backend packages — LDAP, rate limit, RPC, tokens |
-| [internal/web/AGENTS.md](./internal/web/AGENTS.md) | Frontend — TypeScript, Tailwind CSS, WCAG 2.2 AAA |
+| Path                                               | Scope                                               |
+| -------------------------------------------------- | --------------------------------------------------- |
+| [internal/AGENTS.md](./internal/AGENTS.md)         | Go backend packages — LDAP, rate limit, RPC, tokens |
+| [internal/web/AGENTS.md](./internal/web/AGENTS.md) | Frontend — TypeScript, Tailwind CSS, WCAG 2.2 AAA   |
 
 ## Project
 
@@ -21,21 +21,21 @@ LDAP self-service password changer (hybrid Go + TypeScript web app). Email-based
 
 Source: `package.json` scripts + `go test`. All commands runnable from repo root.
 
-| Task            | Command                                       |
-| --------------- | --------------------------------------------- |
-| Install deps    | `bun install --frozen-lockfile`               |
-| Dev (all watch) | `bun run dev`                                 |
-| Build all       | `bun run build`                               |
-| Build assets    | `bun run build:assets`                        |
-| TS watch        | `bun run js:dev`                              |
-| TS build/check  | `bun run js:build`                            |
-| CSS watch       | `bun run css:dev`                             |
-| CSS build       | `bun run css:build`                           |
-| Go test         | `go test -v -race ./...`                      |
-| Go build        | `go build -v ./...`                           |
-| Format          | `bunx prettier --write .`                     |
-| Format check    | `bunx prettier --check .`                     |
-| Lint TS         | `bun run lint` (or `bun run lint:fix`)        |
+| Task            | Command                                                   |
+| --------------- | --------------------------------------------------------- |
+| Install deps    | `bun install --frozen-lockfile`                           |
+| Dev (all watch) | `bun run dev`                                             |
+| Build all       | `bun run build`                                           |
+| Build assets    | `bun run build:assets`                                    |
+| TS watch        | `bun run js:dev`                                          |
+| TS build/check  | `bun run js:build`                                        |
+| CSS watch       | `bun run css:dev`                                         |
+| CSS build       | `bun run css:build`                                       |
+| Go test         | `go test -v -race ./...`                                  |
+| Go build        | `go build -v ./...`                                       |
+| Format          | `bunx prettier --write .`                                 |
+| Format check    | `bunx prettier --check .`                                 |
+| Lint TS         | `bun run lint` (or `bun run lint:fix`)                    |
 | Lint Go         | `golangci-lint run` (CI: `golangci/golangci-lint-action`) |
 
 **Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,305 +1,121 @@
-# Agent Guidelines
+# AGENTS.md
 
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-02-22 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-04-18 -->
 
-**Precedence**: Nearest AGENTS.md wins. This is the root file with global defaults.
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. This root holds global defaults only; scoped files override.
 
-**Project**: LDAP Selfservice Password Changer — hybrid Go + TypeScript web application with WCAG 2.2 AAA accessibility compliance.
+## Index of scoped AGENTS.md
 
-## Quick Navigation
+| Path                                             | Scope                                               |
+| ------------------------------------------------ | --------------------------------------------------- |
+| [internal/AGENTS.md](./internal/AGENTS.md)       | Go backend packages — LDAP, rate limit, RPC, tokens |
+| [internal/web/AGENTS.md](./internal/web/AGENTS.md) | Frontend — TypeScript, Tailwind CSS, WCAG 2.2 AAA |
 
-- [internal/AGENTS.md](internal/AGENTS.md) - Go backend services
-- [internal/web/AGENTS.md](internal/web/AGENTS.md) - TypeScript frontend & Tailwind CSS
+## Project
 
-## Global Defaults
+LDAP self-service password changer (hybrid Go + TypeScript web app). Email-based reset, rate limiting, WCAG 2.2 AAA compliance. Single binary deployment with embedded assets.
 
-### Project Overview
+**Stack**: Go 1.26 + Fiber v3, TypeScript (ultra-strict), Tailwind CSS 4, Docker multi-stage, **Bun** (migrated from pnpm in [`8f69f47`](https://github.com/netresearch/ldap-selfservice-password-changer/commit/8f69f47)).
 
-Self-service password change/reset web app for LDAP/ActiveDirectory with email-based password reset, rate limiting, and strict accessibility standards. Single binary deployment with embedded assets.
+## Commands
 
-**Stack**: Go 1.26 + Fiber v3, TypeScript (ultra-strict), Tailwind CSS 4, Docker multi-stage builds, pnpm 10.30
+Source: `package.json` scripts + `go test`. All commands runnable from repo root.
 
-**Key characteristics**:
+| Task            | Command                                       |
+| --------------- | --------------------------------------------- |
+| Install deps    | `bun install --frozen-lockfile`               |
+| Dev (all watch) | `bun run dev`                                 |
+| Build all       | `bun run build`                               |
+| Build assets    | `bun run build:assets`                        |
+| TS watch        | `bun run js:dev`                              |
+| TS build/check  | `bun run js:build`                            |
+| CSS watch       | `bun run css:dev`                             |
+| CSS build       | `bun run css:build`                           |
+| Go test         | `go test -v -race ./...`                      |
+| Go build        | `go build -v ./...`                           |
+| Format          | `bunx prettier --write .`                     |
+| Format check    | `bunx prettier --check .`                     |
+| Lint TS         | `bun run lint` (or `bun run lint:fix`)        |
+| Lint Go         | `golangci-lint run` (CI: `golangci/golangci-lint-action`) |
 
-- Docker-first: All dev/CI must work via Docker
-- Accessibility: WCAG 2.2 AAA compliance (7:1 contrast, keyboard nav, screen readers)
-- Type-safe: Go with testcontainers, TypeScript with all strict flags
-- Security-focused: LDAPS, rate limiting, token-based reset, no password storage
+**Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.
 
-### Setup
+## Workflow
 
-**Prerequisites**: Docker + Docker Compose (required), Go 1.26+, Node.js 24+, pnpm 10.28+ (for native dev)
+1. Before coding, read the nearest `AGENTS.md` for the area you're touching.
+2. After a change: smallest relevant check (`bun run js:build` for TS, `go test ./pkg/...` for Go).
+3. Before committing: `bunx prettier --write .` + full `go test ./...` if ≥2 files or shared code.
+4. Before claiming done: run verification, **show output as evidence** — never "try again" or "should work now" without proof.
+
+## Security (global)
+
+- **No secrets in git.** Use `.env.local` (gitignored). Never commit LDAP/SMTP credentials.
+- **LDAPS required** in production (`ldaps://` URLs).
+- **No PII logging** — passwords, tokens, session IDs never reach logs.
+- **Rate limiting** 3 req/hour/IP (configurable via `RATE_LIMIT_*`).
+- **Cryptographic random tokens** with configurable expiry; single-use, server-side.
+- **Strict input validation** at boundaries — see `internal/validators/`.
+- **Container runs as UID 65534** (nobody), not root.
+- **Renovate** handles dependency updates; review major-version changelogs.
+
+## PR/Commit Checklist
+
+Before commit:
+
+- [ ] `bunx prettier --write .`
+- [ ] `bun run js:build` (TypeScript strict)
+- [ ] `go test ./...`
+- [ ] `go build`
+- [ ] No secrets in staged files
+- [ ] Docs updated if behavior changed
+- [ ] WCAG 2.2 AAA maintained (if UI changed — see [docs/accessibility.md](docs/accessibility.md))
+
+Commit format: [Conventional Commits](https://www.conventionalcommits.org/). Examples: `feat(auth): add reset via email`, `fix(validators): correct regex`, `chore(deps): bump bun`. **No AI attribution** in messages.
+
+PR:
+
+- [ ] CI green (types, formatting, tests, security scans)
+- [ ] Keep small (~≤300 net LOC when possible)
+- [ ] Prefix with ticket ID when applicable
+- [ ] Updated docs land in same PR
+
+## House Rules
+
+- **Docker-first.** Native setup is convenience, not requirement. Use compose profiles: `dev`, `test`.
+- **YAGNI.** Build only what's requested. No speculative features.
+- **Type safety.** TS: no `any`, all strict flags on. Go: `any` (not `interface{}`), `errors.AsType[T]`, wrap errors with context.
+- **Accessibility non-negotiable.** 7:1 contrast, full keyboard nav, screen-reader tested. See [docs/accessibility.md](docs/accessibility.md).
+- **Dependencies.** Keep `bun.lock` and `go.sum` committed. Use top-level `overrides` in `package.json` for transitive CVE fixes when upstream hasn't patched.
+- **CI/CD.** `pr-quality.yml` auto-approves collaborator PRs. `auto-merge-deps.yml` handles Dependabot/Renovate. See [docs/development-guide.md](docs/development-guide.md) for bootstrap.
+
+## Releases
+
+Unified with the org's release pipeline ([`netresearch/.github`](https://github.com/netresearch/.github) reusables).
 
 ```bash
-# Clone and setup environment
-git clone <repo>
-cd ldap-selfservice-password-changer
-cp .env.local.example .env.local  # Edit with your LDAP config
-
-# Docker (recommended)
-docker compose --profile dev up
-
-# Native development
-pnpm install
-go mod download
-pnpm dev  # Runs concurrent TS watch, CSS watch, and Go with hot-reload
+git tag -s vX.Y.Z -m "vX.Y.Z"    # annotated + signed tag (required)
+git push origin vX.Y.Z            # triggers release.yml
 ```
 
-See [docs/development-guide.md](docs/development-guide.md) for comprehensive setup.
+Pipeline (see [.github/workflows/release.yml](.github/workflows/release.yml)):
 
-### Build & Test Commands
+1. **`create-release`** — creates GitHub Release; computes `make_latest` from semver vs existing releases (backfills and older-major bugfixes don't steal the Latest badge).
+2. **`goreleaser`** — builds binaries, archives, per-archive Syft SBOMs, cosign-signed `checksums.txt`; attests archives+SBOMs via `actions/attest-build-provenance`.
+3. **`container`** — multi-arch ghcr.io image, cosign keyless-signed + SLSA provenance.
+4. **`verify-notes`** — appends standardized "Verify your download" block.
 
-**Package manager**: pnpm (specified in package.json: `pnpm@10.30.1`)
+**Backfill**: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
 
-```bash
-# Build everything
-pnpm build                # Build frontend assets + Go binary
+**GoReleaser config notes** ([`.goreleaser.yml`](.goreleaser.yml)):
 
-# Frontend only
-pnpm build:assets         # TypeScript + Tailwind CSS
-pnpm js:build             # TypeScript compile + minify
-pnpm css:build            # Tailwind CSS + PostCSS
+- `mode: keep-existing` (preserves create-release's notes; don't change to `replace`)
+- `changelog.use: git` (not `github` — `github` ignores filters)
+- No 32-bit ARM: Fiber v3 `math.MaxUint32` overflows `int` on 32-bit → `linux/arm` excluded
 
-# Development (watch mode)
-pnpm dev                  # Concurrent: TS watch, CSS watch, Go hot-reload
-pnpm js:dev               # TypeScript watch
-pnpm css:dev              # CSS watch
-pnpm go:dev               # Go with nodemon hot-reload
+## When Stuck
 
-# Tests
-go test -v ./...          # All Go tests with verbose output
-go test ./internal/...    # Specific package tests
-
-# Formatting
-pnpm prettier --write .   # Format TS, Go templates, config files
-pnpm prettier --check .   # Check formatting (CI)
-
-# Linting
-pnpm lint                 # ESLint check (TS/JS)
-pnpm lint:fix             # ESLint auto-fix
-
-# Type checking
-pnpm js:build             # TypeScript strict compilation (no emit in dev)
-go build -v ./...         # Go compilation + type checking
-```
-
-**CI commands** (from `.github/workflows/check.yml`):
-
-- Type check: `pnpm js:build` and `go build -v ./...`
-- Format check: `pnpm prettier --check .`
-- Lint Go: `golangci-lint` (via GitHub Action)
-- Lint JS/TS: `pnpm lint`
-- Tests: `go test -v -race ./...` (with coverage)
-
-### Code Style
-
-**TypeScript**:
-
-- Ultra-strict tsconfig: `strict: true`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`
-- Prettier formatting: 120 char width, semicolons, double quotes, 2-space tabs
-- No `any` types - use proper type definitions
-- Follow existing patterns in `internal/web/static/`
-
-**Go**:
-
-- Standard Go formatting (`go fmt`)
-- Prettier with `prettier-plugin-go-template` for HTML templates
-- Follow Go project layout: `internal/` for private packages, `main.go` at root
-- Use testcontainers for integration tests (see `*_test.go` files)
-- Error wrapping with context
-- Go 1.26 idioms: `wg.Go()`, `errors.AsType[T]`, `b.Loop()`, `any` (not `interface{}`)
-
-**General**:
-
-- Composition over inheritance
-- SOLID, KISS, DRY, YAGNI principles
-- Law of Demeter: minimize coupling
-- No secrets in VCS (use .env.local, excluded from git)
-
-### Security
-
-- **No secrets in git**: Use `.env.local` (gitignored), never commit LDAP credentials
-- **LDAPS required**: Production must use encrypted LDAP connections
-- **Rate limiting**: 3 requests/hour per IP (configurable via `RATE_LIMIT_*` env vars)
-- **Token security**: Cryptographic random tokens with configurable expiry
-- **Input validation**: Strict validation on all user inputs (see `internal/validators/`)
-- **Dependency scanning**: Renovate enabled, review changelogs for major updates
-- **No PII logging**: Redact sensitive data in logs
-- **Run as non-root**: Dockerfile uses UID 65534 (nobody)
-
-### PR/Commit Checklist
-
-✅ **Before commit**:
-
-- [ ] Run `pnpm prettier --write .` (format all)
-- [ ] Run `pnpm js:build` (TypeScript strict check)
-- [ ] Run `go test ./...` (all tests pass)
-- [ ] Run `go build` (compilation check)
-- [ ] No secrets in changed files
-- [ ] Update docs if behavior changed
-- [ ] WCAG 2.2 AAA compliance maintained (if UI changed)
-
-✅ **Commit format**: Conventional Commits
-
-```
-type(scope): description
-
-Examples:
-feat(auth): add password reset via email
-fix(validators): correct password policy regex
-docs(api): update JSON-RPC examples
-chore(deps): update pnpm to v10.18.1
-```
-
-**No Claude attribution** in commit messages.
-
-✅ **PR requirements**:
-
-- [ ] All CI checks pass (types, formatting, tests)
-- [ ] Keep PRs small (~≤300 net LOC if possible)
-- [ ] Include ticket ID if applicable: `fix(rate-limit): ISSUE-123: fix memory leak`
-- [ ] Update relevant docs in same PR (README, AGENTS.md, docs/)
-
-### Good vs Bad Examples
-
-**✅ Good - TypeScript strict types**:
-
-```typescript
-interface PasswordPolicy {
-  minLength: number;
-  requireNumbers: boolean;
-}
-
-function validatePassword(password: string, policy: PasswordPolicy): boolean {
-  const hasNumber = /\d/.test(password);
-  return password.length >= policy.minLength && (!policy.requireNumbers || hasNumber);
-}
-```
-
-**❌ Bad - Using any or unsafe access**:
-
-```typescript
-function validatePassword(password: any, policy: any) {
-  // ❌ any types
-  return password.length >= policy.minLength; // ❌ unsafe access
-}
-```
-
-**✅ Good - Go error handling**:
-
-```go
-func connectLDAP(config LDAPConfig) (*ldap.Conn, error) {
-    conn, err := ldap.DialURL(config.URL)
-    if err != nil {
-        return nil, fmt.Errorf("failed to connect to LDAP at %s: %w", config.URL, err)
-    }
-    return conn, nil
-}
-```
-
-**❌ Bad - Ignoring errors**:
-
-```go
-func connectLDAP(config LDAPConfig) *ldap.Conn {
-    conn, _ := ldap.DialURL(config.URL)  // ❌ ignoring error
-    return conn                           // ❌ may return nil
-}
-```
-
-**✅ Good - Accessible UI**:
-
-```html
-<button type="submit" aria-label="Submit password change" class="bg-blue-600 hover:bg-blue-700 focus:ring-4">
-  Change Password
-</button>
-```
-
-**❌ Bad - Inaccessible UI**:
-
-```html
-<div onclick="submit()">Submit</div>
-❌ not keyboard accessible, wrong semantics
-```
-
-### When Stuck
-
-1. **Check existing docs**: [docs/](docs/) has comprehensive guides
-2. **Review similar code**: Look for patterns in `internal/` packages
-3. **Run tests**: `go test -v ./...` often reveals issues
-4. **Check CI logs**: GitHub Actions shows exact failure points
-5. **Verify environment**: Ensure `.env.local` is properly configured
-6. **Docker issues**: `docker compose down -v && docker compose --profile dev up --build`
-7. **Type errors**: Review `tsconfig.json` strict flags, use proper types
-8. **Accessibility**: See [docs/accessibility.md](docs/accessibility.md) for WCAG 2.2 AAA guidelines
-
-### House Rules
-
-**Docker-First Philosophy**:
-
-- All dev and CI must work via Docker Compose
-- Native setup is optional convenience, not requirement
-- Use profiles in compose.yml: `--profile dev` or `--profile test`
-
-**Documentation Currency**:
-
-- Update docs in same PR as code changes
-- No drift between code and documentation
-- Keep README, AGENTS.md, and docs/ synchronized
-
-**Testing Standards**:
-
-- Aim for ≥80% coverage on changed code
-- Use testcontainers for integration tests (see existing `*_test.go`)
-- For bugfixes: write failing test first (TDD)
-- Tests must pass before PR approval
-
-**Scope Discipline**:
-
-- Build only what's requested
-- No speculative features
-- MVP first, iterate based on feedback
-- YAGNI: You Aren't Gonna Need It
-
-**Accessibility Non-Negotiable**:
-
-- WCAG 2.2 AAA compliance required
-- 7:1 contrast ratios for text
-- Full keyboard navigation support
-- Screen reader tested (VoiceOver/NVDA)
-- See [docs/accessibility.md](docs/accessibility.md)
-
-**Commit Practices**:
-
-- Atomic commits: one logical change per commit
-- Conventional Commits format enforced
-- Never commit secrets or `.env.local`
-- Keep PRs focused and reviewable
-
-**Type Safety**:
-
-- TypeScript: No `any`, all strict flags enabled
-- Go: Leverage type system, use `any` (not `interface{}`), use `errors.AsType[T]`
-- Validate inputs at boundaries
-
-**Dependency Management**:
-
-- Renovate auto-updates enabled
-- Major version updates require changelog review
-- Use Context7 MCP or official docs for migrations
-- Keep pnpm-lock.yaml and go.sum committed
-- Use `pnpm.overrides` for transitive dependency CVE fixes when upstream hasn't patched yet
-- Don't add redundant direct deps if a unified package re-exports them (e.g., `typescript-eslint` provides `@typescript-eslint/parser` + `@typescript-eslint/eslint-plugin`)
-
-**CI/CD Workflows**:
-
-- `pr-quality.yml`: Auto-approves PRs from repo collaborators (solo-maintainer pattern)
-- `auto-merge-deps.yml`: Auto-merges Dependabot/Renovate PRs with strategy auto-detection
-- Bootstrap: The PR introducing `pr-quality.yml` requires manual approval; all subsequent PRs auto-approve
-- `release.yml`: GoReleaser triggered on tag push; pnpm setup must precede setup-node
-
-**Releases (GoReleaser)**:
-
-- Create signed tag locally: `git tag -s vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
-- GoReleaser config: `.goreleaser.yml` with `use: git` for changelog (not `use: github` — ignores filters)
-- `mode: replace` overwrites release notes — update via API after GoReleaser if needed
-- No 32-bit ARM builds: Fiber v3 `math.MaxUint32` overflows on 32-bit (`linux/arm` excluded)
+1. Scoped `AGENTS.md` for the area → code in `internal/` → [docs/](docs/).
+2. Similar patterns: search git history / existing tests.
+3. `go test -v ./...` surfaces many problems.
+4. Docker weirdness: `docker compose down -v && docker compose --profile dev up --build`.
+5. Env config: `.env.local` vs `.env.local.example`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,6 @@ Source: `package.json` scripts + `go test`. Run from repo root.
 
 **Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.
 
-**Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.
-
 ## Workflow
 
 1. Before coding, read the nearest `AGENTS.md` for the area you're touching.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,24 +19,28 @@ LDAP self-service password changer (hybrid Go + TypeScript web app). Email-based
 
 ## Commands
 
-Source: `package.json` scripts + `go test`. All commands runnable from repo root.
+Source: `package.json` scripts + `go test`. Run from repo root.
 
-| Task            | Command                                                   |
-| --------------- | --------------------------------------------------------- |
-| Install deps    | `bun install --frozen-lockfile`                           |
-| Dev (all watch) | `bun run dev`                                             |
-| Build all       | `bun run build`                                           |
-| Build assets    | `bun run build:assets`                                    |
-| TS watch        | `bun run js:dev`                                          |
-| TS build/check  | `bun run js:build`                                        |
-| CSS watch       | `bun run css:dev`                                         |
-| CSS build       | `bun run css:build`                                       |
-| Go test         | `go test -v -race ./...`                                  |
-| Go build        | `go build -v ./...`                                       |
-| Format          | `bunx prettier --write .`                                 |
-| Format check    | `bunx prettier --check .`                                 |
-| Lint TS         | `bun run lint` (or `bun run lint:fix`)                    |
-| Lint Go         | `golangci-lint run` (CI: `golangci/golangci-lint-action`) |
+| Task                    | Command                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------- |
+| Install deps            | `bun install` (CI; adds `--frozen-lockfile` for reproducible release builds)                            |
+| Dev (all watch)         | `bun run dev` (runs `build:assets` then TS/CSS watchers + `air` for Go hot-reload)                      |
+| Build all               | `bun run build`                                                                                         |
+| Build assets            | `bun run build:assets` (Tailwind CSS + `tsc`)                                                           |
+| TS watch                | `bun run js:dev`                                                                                        |
+| TS type-check / compile | `bun run js:build` (runs `tsc`; no minifier configured)                                                 |
+| CSS watch               | `bun run css:dev`                                                                                       |
+| CSS build               | `bun run css:build`                                                                                     |
+| Go test                 | `go test -v -race ./...`                                                                                |
+| Go build                | `go build -v ./...`                                                                                     |
+| Format                  | `bunx prettier --write .`                                                                               |
+| Format check            | `bunx prettier --check .`                                                                               |
+| Lint TS                 | `bun run lint` (or `bun run lint:fix`)                                                                  |
+| Lint Go                 | CI runs via `golangci/golangci-lint-action`. Locally: install `golangci-lint` then `golangci-lint run`. |
+
+**Toolchain install**: Bun and Go are installed separately (no `packageManager`/`engines` pins in `package.json`). `air` is declared as a bun script dep; `golangci-lint` is not — install via `go install` or your package manager.
+
+**Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.
 
 **Docker-first**: `docker compose --profile dev up` is the canonical dev path; native Bun/Go is optional convenience.
 

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -58,7 +58,7 @@ TOKEN_EXPIRY_DURATION=1h
 
 ```bash
 # Development
-go run .                      # Start server with hot-reload (via bun run dev)
+go run .                      # Start server once (no hot-reload). For hot-reload, run `bun run dev` which invokes `air`.
 go build -v ./...             # Compile all packages
 go test -v ./...              # Run all tests with verbose output
 

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,6 +1,6 @@
 # Go Backend Services
 
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-02-22 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-04-18 -->
 
 **Scope**: Go backend packages in `internal/` directory
 
@@ -58,7 +58,7 @@ TOKEN_EXPIRY_DURATION=1h
 
 ```bash
 # Development
-go run .                      # Start server with hot-reload (via pnpm go:dev)
+go run .                      # Start server with hot-reload (via bun run dev)
 go build -v ./...             # Compile all packages
 go test -v ./...              # Run all tests with verbose output
 
@@ -184,7 +184,7 @@ conn, _ := ldap.Dial(url)
 
 **Before committing Go code**:
 
-- [ ] Run `go fmt ./...` (or `pnpm prettier --write .`)
+- [ ] Run `go fmt ./...` (or `bunx prettier --write .`)
 - [ ] Run `go vet ./...` (static analysis)
 - [ ] Run `go test ./...` (all tests pass)
 - [ ] Run `go build` (compilation check)

--- a/internal/web/AGENTS.md
+++ b/internal/web/AGENTS.md
@@ -1,6 +1,6 @@
 # Frontend - TypeScript & Tailwind CSS
 
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-02-04 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-04-18 -->
 
 **Scope**: Frontend assets in `internal/web/` directory - TypeScript, Tailwind CSS, HTML templates
 
@@ -31,17 +31,17 @@ Note: HTTP handlers, middleware, and server setup are in `main.go` at the projec
 
 ## Setup/Environment
 
-**Prerequisites**: Node.js 24+, pnpm 10.28+ (from root `package.json`)
+**Prerequisites**: Node.js 24+, Bun 1.1+ (from root `package.json`)
 
 ```bash
 # From project root
-pnpm install          # Install dependencies
+bun install --frozen-lockfile          # Install dependencies
 
 # Development (watch mode)
-pnpm css:dev          # Tailwind CSS watch
-pnpm js:dev           # TypeScript watch
+bun run css:dev          # Tailwind CSS watch
+bun run js:dev           # TypeScript watch
 # OR
-pnpm dev              # Concurrent: CSS + TS + Go hot-reload
+bun run dev              # Concurrent: CSS + TS + Go hot-reload
 ```
 
 **No .env needed for frontend** - all config comes from Go backend
@@ -52,20 +52,20 @@ pnpm dev              # Concurrent: CSS + TS + Go hot-reload
 
 ```bash
 # Build frontend assets
-pnpm build:assets     # TypeScript + CSS (production builds)
+bun run build:assets     # TypeScript + CSS (production builds)
 
 # TypeScript
-pnpm js:build         # Compile TS → ES modules + minify
-pnpm js:dev           # Watch mode with preserveWatchOutput
+bun run js:build         # Compile TS → ES modules + minify
+bun run js:dev           # Watch mode with preserveWatchOutput
 tsc --noEmit          # Type check only (no output)
 
 # CSS
-pnpm css:build        # Tailwind + PostCSS → styles.css
-pnpm css:dev          # Watch mode
+bun run css:build        # Tailwind + PostCSS → styles.css
+bun run css:dev          # Watch mode
 
 # Formatting
-pnpm prettier --write internal/web/    # Format TS, CSS, HTML templates
-pnpm prettier --check internal/web/    # Check formatting (CI)
+bunx prettier --write internal/web/    # Format TS, CSS, HTML templates
+bunx prettier --check internal/web/    # Check formatting (CI)
 ```
 
 **No unit tests yet** - TypeScript strict mode catches most errors, integration via Go tests
@@ -73,9 +73,9 @@ pnpm prettier --check internal/web/    # Check formatting (CI)
 **CI validation** (from `.github/workflows/check.yml`):
 
 ```bash
-pnpm install
-pnpm js:build         # TypeScript strict compilation
-pnpm prettier --check .
+bun install --frozen-lockfile
+bun run js:build         # TypeScript strict compilation
+bunx prettier --check .
 ```
 
 **Accessibility testing**:
@@ -306,12 +306,30 @@ if (first) {
 console.log(items[0].toUpperCase()); // ❌ may crash if empty array
 ```
 
+## Security
+
+**Threat model**: frontend assets are served to unauthenticated users and rendered in their browser. Treat everything that reaches the DOM as potentially attacker-controlled.
+
+- **No inline scripts.** Content-Security-Policy rejects them. All JS lives in `static/js/*.ts` → compiled to ES modules and loaded via `<script type="module" src=...>`.
+- **Escape at the template boundary.** Go templates auto-escape via `html/template`; never emit raw HTML into a template. For dynamic values that must include markup, sanitize server-side before rendering.
+- **No `innerHTML` for user-controlled data.** Use `textContent` or build DOM nodes with `createElement`. Only `innerHTML` a known-static string.
+- **No `eval` / `Function(...)` / `setTimeout(stringArg)`.** Treat these as banned — they bypass CSP and taint the whole page.
+- **Autocomplete hygiene.** New-password fields MUST set `autocomplete="new-password"`; current-password fields use `autocomplete="current-password"`. Wrong or missing autocomplete confuses password managers and can cause them to fill wrong values.
+- **Password-manager-friendly forms.** Every password input sits inside a `<form>` with proper `<label>`. Don't hide real `<input type="password">` behind a fake div — managers won't detect it.
+- **No PII in client logs.** Never `console.log` passwords, tokens, usernames, or email addresses. Strip diagnostic logs before committing.
+- **No third-party scripts.** Keep the CSP strict; no CDN-hosted libraries, no analytics, no remote fonts. All assets ship from the same origin via Go's embedded FS.
+- **Focus trap on modals.** Any dialog must trap focus while open (for security + a11y). Escape must close and restore focus.
+- **Subresource integrity.** If a local asset ever must reference an external URL (shouldn't happen here), pin with SRI hashes.
+- **Tailwind classes are static.** Never template-compose class names from user data — JIT won't pick them up and the attacker could produce unexpected styling. Always full static strings.
+
+**Verify**: browser DevTools → Network → confirm CSP header `default-src 'self'` (or stricter). Console → no CSP violations.
+
 ## PR/Commit Checklist
 
 **Before committing frontend code**:
 
-- [ ] Run `pnpm js:build` (TypeScript strict check)
-- [ ] Run `pnpm prettier --write internal/web/`
+- [ ] Run `bun run js:build` (TypeScript strict check)
+- [ ] Run `bunx prettier --write internal/web/`
 - [ ] Verify keyboard navigation works
 - [ ] Test with screen reader (VoiceOver/NVDA)
 - [ ] Check contrast ratios (7:1 for text)
@@ -332,7 +350,7 @@ console.log(items[0].toUpperCase()); // ❌ may crash if empty array
 
 **Performance checklist**:
 
-- [ ] Minified JS (via `pnpm js:minify`)
+- [ ] Minified JS (via `bun run js:build`)
 - [ ] CSS optimized (cssnano via PostCSS)
 - [ ] No unused Tailwind classes (purged automatically)
 - [ ] No console.log in production code
@@ -407,11 +425,11 @@ function showError(input: any, message: string) {
 1. **Type errors**: Check `tsconfig.json` flags, use proper types (no `any`)
 2. **Null errors**: Add null checks or type guards
 3. **Module errors**: Ensure ES module syntax (`import`/`export`)
-4. **Build errors**: `pnpm install` to refresh dependencies
+4. **Build errors**: `bun install --frozen-lockfile` to refresh dependencies
 
 **CSS issues**:
 
-1. **Styles not applying**: Check Tailwind purge config, rebuild with `pnpm css:build`
+1. **Styles not applying**: Check Tailwind purge config, rebuild with `bun run css:build`
 2. **Dark mode broken**: Use `dark:` prefix on utilities
 3. **Responsive broken**: Use `md:`, `lg:` breakpoint prefixes
 4. **Custom classes**: Don't - use Tailwind utilities instead

--- a/internal/web/AGENTS.md
+++ b/internal/web/AGENTS.md
@@ -31,7 +31,7 @@ Note: HTTP handlers, middleware, and server setup are in `main.go` at the projec
 
 ## Setup/Environment
 
-**Prerequisites**: Node.js 24+, Bun 1.1+ (from root `package.json`)
+**Prerequisites**: Bun 1.1+ (install separately; `package.json` does not pin `packageManager` or `engines`). Node.js only needed for tooling that doesn't run under Bun.
 
 ```bash
 # From project root
@@ -55,7 +55,7 @@ bun run dev              # Concurrent: CSS + TS + Go hot-reload
 bun run build:assets     # TypeScript + CSS (production builds)
 
 # TypeScript
-bun run js:build         # Compile TS → ES modules + minify
+bun run js:build         # Compile TS → ES modules (type-check; no minifier configured)
 bun run js:dev           # Watch mode with preserveWatchOutput
 tsc --noEmit          # Type check only (no output)
 
@@ -70,11 +70,17 @@ bunx prettier --check internal/web/    # Check formatting (CI)
 
 **No unit tests yet** - TypeScript strict mode catches most errors, integration via Go tests
 
-**CI validation** (from `.github/workflows/check.yml`):
+**CI validation** (`.github/workflows/check.yml`):
 
 ```bash
-bun install --frozen-lockfile
+# "Check types" job
+bun install
 bun run js:build         # TypeScript strict compilation
+```
+
+```bash
+# "Check formatting" job (separate)
+bun install
 bunx prettier --check .
 ```
 
@@ -350,7 +356,7 @@ console.log(items[0].toUpperCase()); // ❌ may crash if empty array
 
 **Performance checklist**:
 
-- [ ] Minified JS (via `bun run js:build`)
+- [ ] TypeScript compiled cleanly (`bun run js:build`; no minification step is configured today — if added, reference it here)
 - [ ] CSS optimized (cssnano via PostCSS)
 - [ ] No unused Tailwind classes (purged automatically)
 - [ ] No console.log in production code


### PR DESCRIPTION
Refreshes all three AGENTS.md files in this repo using the \`agent-rules\` skill. Addresses staleness flagged by gemini-code-assist on #533 (pnpm references, release-mode drift) plus validator issues (bloated root, missing scope index, missing Security section).

## Changes

**Root AGENTS.md** — 305 → 121 lines:

- Adopts thin style with proper \"Index of scoped AGENTS.md\" section (validator-compliant)
- All \`pnpm\` references → \`bun\` (project migrated in [\`8f69f47\`](https://github.com/netresearch/ldap-selfservice-password-changer/commit/8f69f47))
- Commands table synced to current \`package.json\` scripts
- **Releases section rewritten** to reflect the unified pipeline (create-release → goreleaser → container → verify-notes). Correct \`mode: keep-existing\`, computed \`make_latest\`, signed-tag enforcement. Replaces the obsolete \`mode: replace\` advice.
- Removes long TS/Go code examples (already in scoped files)

**internal/AGENTS.md** — minor \`pnpm\` → \`bun\` fixes.

**internal/web/AGENTS.md**:

- \`pnpm\` → \`bun\` throughout
- **New Security section** (was missing per validator) — XSS guards (no innerHTML for user data, no eval/Function), CSP hygiene (no inline scripts, no third-party CDNs, SRI), autocomplete/password-manager conventions, focus-trap rules, static-only Tailwind classes

## Validation (agent-rules skill)

| Script | Result |
|---|---|
| \`validate-structure.sh\` | ✅ All checks pass (was: 3 errors) |
| \`check-freshness.sh\` | ✅ Up to date (3/3) |
| \`verify-commands.sh\` | ✅ All bun scripts + go + golangci-lint resolve |

## Before / after

| Metric | Before | After |
|---|---|---|
| Root AGENTS.md lines | 305 | 121 |
| Scope index | ❌ bad format | ✅ validator-compliant |
| Precedence statement | ✅ | ✅ |
| pnpm references | 28+ | 0 |
| internal/web Security section | ❌ missing | ✅ added |
| Last updated | 2026-02-22 / 02-04 | 2026-04-18 |