### PR TITLE
a11y, UX & bug fixes: live password-policy checklist, linked error summary, config-loading fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage.out
 coverage.html
 *.coverprofile
 tmp/
+
+# Playwright MCP snapshot artifacts
+.playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ bun.lock
 renovate.json
 # Ignore HTML template files (Go templates with special syntax)
 internal/web/templates/**/*.html
+# Playwright MCP snapshot artifacts
+.playwright-mcp/

--- a/cmd/uitest/main.go
+++ b/cmd/uitest/main.go
@@ -1,0 +1,68 @@
+//go:build uitest
+
+// Ad-hoc dev server for Playwright / browser UI testing. Renders the real
+// templates and serves the real static assets, without LDAP/SMTP.
+// Run with: `go run -tags=uitest ./cmd/uitest`. Not built in normal builds.
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/static"
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/options"
+	webstatic "github.com/netresearch/ldap-selfservice-password-changer/internal/web/static"
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/web/templates"
+)
+
+func main() {
+	opts := &options.Opts{
+		Port:                        "3333",
+		MinLength:                   10,
+		MinNumbers:                  2,
+		MinSymbols:                  1,
+		MinUppercase:                1,
+		MinLowercase:                1,
+		PasswordCanIncludeUsername:  false,
+		PasswordResetEnabled:        true,
+		ResetTokenExpiryMinutes:     15,
+		ResetRateLimitRequests:      3,
+		ResetRateLimitWindowMinutes: 60,
+	}
+
+	index, err := templates.RenderIndex(opts)
+	if err != nil {
+		log.Fatalf("render index: %v", err)
+	}
+	forgot, err := templates.RenderForgotPassword()
+	if err != nil {
+		log.Fatalf("render forgot: %v", err)
+	}
+	reset, err := templates.RenderResetPassword(opts)
+	if err != nil {
+		log.Fatalf("render reset: %v", err)
+	}
+
+	app := fiber.New()
+	app.Use("/static", static.New("", static.Config{FS: webstatic.Static}))
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set("Content-Type", fiber.MIMETextHTMLCharsetUTF8)
+		return c.Send(index)
+	})
+	app.Get("/forgot-password", func(c fiber.Ctx) error {
+		c.Set("Content-Type", fiber.MIMETextHTMLCharsetUTF8)
+		return c.Send(forgot)
+	})
+	app.Get("/reset-password", func(c fiber.Ctx) error {
+		c.Set("Content-Type", fiber.MIMETextHTMLCharsetUTF8)
+		return c.Send(reset)
+	})
+	app.Post("/api/rpc", func(c fiber.Ctx) error {
+		return c.Status(http.StatusOK).JSON(fiber.Map{"success": true, "data": []string{}})
+	})
+	log.Println("listening on :3333")
+	if err := app.Listen(":3333"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/web/static/js/app-init.ts
+++ b/internal/web/static/js/app-init.ts
@@ -1,15 +1,15 @@
 /**
- * App initialization wrapper - reads configuration from data attributes
- * for CSP compliance (no inline scripts)
+ * App initialization wrapper — reads configuration from data attributes
+ * for CSP compliance (no inline scripts).
+ *
+ * NOTE: `document.currentScript` is ALWAYS null inside ES modules (per spec),
+ * so we look the script up explicitly by src.
  */
 
 import { init } from "./app.js";
 
-// Get the current script element to read data attributes
-// Note: document.currentScript can be null in ES6 modules, so we provide fallback
-const currentScript = document.currentScript as HTMLScriptElement | null;
+const currentScript = document.querySelector<HTMLScriptElement>('script[src*="app-init.js"]');
 
-// Read configuration from data attributes with defaults
 const config = {
   minLength: Number(currentScript?.dataset["minLength"] ?? "8"),
   minNumbers: Number(currentScript?.dataset["minNumbers"] ?? "0"),
@@ -19,5 +19,4 @@ const config = {
   passwordCanIncludeUsername: currentScript?.dataset["passwordCanIncludeUsername"] === "true"
 };
 
-// Initialize the app with configuration (always call, even with defaults)
 init(config);

--- a/internal/web/static/js/app.ts
+++ b/internal/web/static/js/app.ts
@@ -46,11 +46,13 @@ export const init = (opts: Opts) => {
   const errorSummaryText = errorSummary.querySelector<HTMLSpanElement>("span[data-purpose='summaryText']");
   if (!errorSummaryText) throw new Error("Could not find error summary text element");
 
-  const submitButton = form.querySelector<HTMLButtonElement>("& > div[data-purpose='submit'] > button[type='submit']");
+  const submitButton = form.querySelector<HTMLButtonElement>(
+    ":scope > div[data-purpose='submit'] > button[type='submit']"
+  );
   if (!submitButton) throw new Error("Could not find submit button element");
 
   const submitErrorContainer = form.querySelector<HTMLDivElement>(
-    "& > div[data-purpose='submit'] > div[data-purpose='errors']"
+    ":scope > div[data-purpose='submit'] > div[data-purpose='errors']"
   );
   if (!submitErrorContainer) throw new Error("Could not find submit error container element");
 
@@ -75,8 +77,8 @@ export const init = (opts: Opts) => {
     ],
     [
       "confirm_password",
-      "Password Confirmation",
-      [mustNotBeEmpty("Password Confirmation"), mustMatchNewPassword("Password Confirmation")]
+      "Confirm New Password",
+      [mustNotBeEmpty("Confirm New Password"), mustMatchNewPassword("Confirm New Password")]
     ]
   ] satisfies Field[];
 
@@ -93,11 +95,10 @@ export const init = (opts: Opts) => {
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
-    const getErrors = (): string[] =>
-      validators
-        .map((v) => v(getValue()))
-        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
-    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
+    const getErrors = (): string[] => validators.map((v) => v(getValue())).filter((msg) => msg.length > 0);
+    const paint = (errors: string[]) => {
+      setFieldErrors(errorContainer, inputContainer, input, errors);
+    };
     const paintBorderOnly = (invalid: boolean) => {
       // Strip any inline text from previous full paints, keep border state.
       while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
@@ -141,7 +142,9 @@ export const init = (opts: Opts) => {
   if (policyUpdater && newPasswordField) {
     policyUpdater(newPasswordField.getValue());
     // Replace paint() with a version that flips border/aria-invalid only.
-    newPasswordField.paint = (errors) => newPasswordField.paintBorderOnly(errors.length > 0);
+    newPasswordField.paint = (errors) => {
+      newPasswordField.paintBorderOnly(errors.length > 0);
+    };
   }
 
   const touched = new Set<string>();
@@ -200,7 +203,7 @@ export const init = (opts: Opts) => {
     }
   });
 
-  form.addEventListener("submit", async (e) => {
+  const handleSubmit = async (e: SubmitEvent): Promise<void> => {
     e.preventDefault();
 
     // Paint every field red; the user is trying to submit, so they should
@@ -247,5 +250,9 @@ export const init = (opts: Opts) => {
       setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
     }
+  };
+
+  form.addEventListener("submit", (e) => {
+    void handleSubmit(e);
   });
 };

--- a/internal/web/static/js/app.ts
+++ b/internal/web/static/js/app.ts
@@ -1,4 +1,5 @@
 import {
+  buildPolicyRules,
   mustBeLongerThan,
   mustIncludeLowercase,
   mustIncludeNumbers,
@@ -11,7 +12,14 @@ import {
   toggleValidator
 } from "./validators.js";
 import { initThemeToggle, initDensityToggle } from "./toggles.js";
-import { setFieldErrors, updateErrorSummary } from "./error-utils.js";
+import {
+  type FieldError,
+  setFieldErrors,
+  setFieldInvalidStyle,
+  setSubmitError,
+  updateErrorSummary
+} from "./error-utils.js";
+import { renderPolicyList } from "./policy-ui.js";
 
 interface Opts {
   minLength: number;
@@ -23,11 +31,10 @@ interface Opts {
 }
 
 export const init = (opts: Opts) => {
-  // Initialize theme and density toggles
   initThemeToggle();
   initDensityToggle();
 
-  const successContainer = document.querySelector<HTMLFormElement>("div[data-purpose='successContainer']");
+  const successContainer = document.querySelector<HTMLDivElement>("div[data-purpose='successContainer']");
   if (!successContainer) throw new Error("Could not find success container element");
 
   const form = document.querySelector<HTMLFormElement>("#form");
@@ -73,106 +80,149 @@ export const init = (opts: Opts) => {
     ]
   ] satisfies Field[];
 
-  const fields = fieldsWithValidators.map(([name, _fieldLabel, validators]) => {
+  const fields = fieldsWithValidators.map(([name, label, validators]) => {
     const f = form.querySelector<HTMLDivElement>(`#${name}`);
     if (!f) throw new Error(`Field "${name}" does not exist`);
-
     const inputContainer = f.querySelector<HTMLDivElement>('div[data-purpose="inputContainer"]');
     if (!inputContainer) throw new Error(`Input container for "${name}" does not exist`);
-
     const input = inputContainer.querySelector<HTMLInputElement>("input");
     if (!input) throw new Error(`Input for "${name}" does not exist`);
-
     const revealButton = f.querySelector<HTMLButtonElement>('button[data-purpose="reveal"]');
     if (!revealButton && input.type === "password") throw new Error(`Reveal button for "${name}" does not exist`);
-
     const errorContainer = f.querySelector<HTMLDivElement>('div[data-purpose="errors"]');
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
-
-    const validate = () => {
-      const value = getValue();
-
-      const errors = validators
-        .map((validate) => validate(value))
-        .reduce<string[]>((acc, v) => {
-          if (v.length > 0) acc.push(v);
-
-          return acc;
-        }, []);
-
-      setFieldErrors(errorContainer, inputContainer, input, errors);
-
-      return errors.length > 0;
+    const getErrors = (): string[] =>
+      validators
+        .map((v) => v(getValue()))
+        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
+    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
+    const paintBorderOnly = (invalid: boolean) => {
+      // Strip any inline text from previous full paints, keep border state.
+      while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
+      setFieldInvalidStyle(inputContainer, input, invalid);
     };
 
     if (revealButton) {
-      revealButton.onclick = (e) => {
+      revealButton.addEventListener("click", (e) => {
         e.preventDefault();
-        e.stopPropagation();
-
         const newType = input.type === "password" ? "text" : "password";
         const revealed = newType === "text";
-
         input.type = newType;
         f.dataset["revealed"] = revealed.toString();
-
-        // Update ARIA label to communicate current state
         revealButton.setAttribute("aria-label", revealed ? "Hide password" : "Show password");
         revealButton.setAttribute("aria-pressed", revealed.toString());
-      };
+      });
     }
 
-    // Help toggle functionality
     const helpButton = f.querySelector<HTMLButtonElement>('button[data-purpose="help"]');
     const helpText = f.querySelector<HTMLDivElement>('div[data-purpose="helpText"]');
-
     if (helpButton && helpText) {
-      helpButton.onclick = (e) => {
+      helpButton.addEventListener("click", (e) => {
         e.preventDefault();
-        e.stopPropagation();
-
         const isExpanded = helpButton.getAttribute("aria-expanded") === "true";
         const newExpanded = !isExpanded;
-
         helpButton.setAttribute("aria-expanded", newExpanded.toString());
         helpText.classList.toggle("hidden", !newExpanded);
-      };
+      });
     }
 
-    return { input, errorContainer, getValue, validate };
+    return { name, label, input, getValue, getErrors, paint, paintBorderOnly };
   });
 
+  // Live policy checklist tied to the New Password field. When present, it
+  // becomes the visual source of truth for password-rule violations — we
+  // suppress the field's inline error text so the user doesn't see the
+  // same rules twice (the red border + aria-invalid still flip on).
+  const policyList = document.querySelector<HTMLUListElement>("#password-policy");
+  const newPasswordField = fields.find((f) => f.name === "new_password");
+  const policyUpdater = policyList && newPasswordField ? renderPolicyList(policyList, buildPolicyRules(opts)) : null;
+  if (policyUpdater && newPasswordField) {
+    policyUpdater(newPasswordField.getValue());
+    // Replace paint() with a version that flips border/aria-invalid only.
+    newPasswordField.paint = (errors) => newPasswordField.paintBorderOnly(errors.length > 0);
+  }
+
+  const touched = new Set<string>();
+
+  const buildSummary = (): FieldError[] => {
+    const out: FieldError[] = [];
+    for (const f of fields) {
+      const errs = f.getErrors();
+      const first = errs[0];
+      if (first) out.push({ fieldId: f.input.id, label: f.label, error: first });
+    }
+    return out;
+  };
+
   const toggleFields = (enabled: boolean) => {
-    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => (el.disabled = !enabled));
+    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => {
+      el.disabled = !enabled;
+    });
     submitButton.dataset["loading"] = (!enabled).toString();
     submitButton.setAttribute("aria-busy", (!enabled).toString());
   };
 
-  form.onsubmit = async (e) => {
+  // On blur: mark the field touched and paint its inline errors.
+  form.addEventListener(
+    "blur",
+    (e) => {
+      const target = e.target as HTMLElement;
+      const f = fields.find((x) => x.input === target);
+      if (!f) return;
+      touched.add(f.name);
+      f.paint(f.getErrors());
+      if (!errorSummary.classList.contains("hidden")) {
+        updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+      }
+    },
+    true // capture: blur doesn't bubble
+  );
+
+  // On every keystroke: update the policy checklist; re-paint the field
+  // being typed into if it has been touched; keep the dependent
+  // `confirm_password` in sync when the user edits `new_password`.
+  form.addEventListener("input", (e) => {
+    if (policyUpdater && newPasswordField) policyUpdater(newPasswordField.getValue());
+
+    const target = e.target as HTMLElement;
+    const f = fields.find((x) => x.input === target);
+    if (f && touched.has(f.name)) f.paint(f.getErrors());
+
+    if (f?.name === "new_password") {
+      const confirm = fields.find((x) => x.name === "confirm_password");
+      if (confirm && touched.has("confirm_password")) confirm.paint(confirm.getErrors());
+    }
+
+    if (!errorSummary.classList.contains("hidden")) {
+      updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+    }
+  });
+
+  form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    e.stopPropagation();
+
+    // Paint every field red; the user is trying to submit, so they should
+    // see all the work that's left.
+    for (const f of fields) {
+      touched.add(f.name);
+      f.paint(f.getErrors());
+    }
+
+    const summary = buildSummary();
+    updateErrorSummary(errorSummary, errorSummaryText, summary, true);
+    if (summary.length > 0) return;
+
+    setSubmitError(submitErrorContainer, "");
+    toggleFields(false);
 
     const [username, oldPassword, newPassword] = fields.map((f) => f.getValue());
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, true); // Focus on submit attempt
-
-    if (hasErrors) return;
-
-    toggleFields(false);
 
     try {
       const res = await fetch("/api/rpc", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           method: "change-password",
           params: [username, oldPassword, newPassword]
@@ -180,44 +230,22 @@ export const init = (opts: Opts) => {
       });
 
       const body = await res.text();
-
       if (!res.ok) {
         let err = body;
-
         try {
           const parsed = JSON.parse(body) as { data?: string[] };
-
           err = parsed.data?.[0] ?? body;
         } catch (_e) {
-          // Ignore JSON parsing errors, use body as-is
+          // use raw body
         }
-
-        throw new Error(`An error occurred: ${err}`);
+        throw new Error(err);
       }
 
-      form.style.display = "none";
-      successContainer.style.display = "block";
-    } catch (e) {
-      console.error(e);
-
-      submitErrorContainer.innerText = (e as Error).message;
-
-      // Re-enable inputs but keep the submit button disabled,
-      // since we know that this isn't going to work. After the validators
-      // successfully re-run, it will enable the submit button again.
+      form.classList.add("hidden");
+      successContainer.classList.remove("hidden");
+    } catch (err) {
+      setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
-      submitButton.disabled = true;
     }
-  };
-
-  form.onchange = (e) => {
-    e.stopPropagation();
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, false); // Don't focus on change
-  };
+  });
 };

--- a/internal/web/static/js/density-init.ts
+++ b/internal/web/static/js/density-init.ts
@@ -1,12 +1,15 @@
 /**
- * Density initialization - runs before page renders to prevent layout shift
- * Extracted from inline script for CSP compliance
+ * Density initialization - runs before page renders to prevent layout shift.
+ * Extracted from inline script for CSP compliance.
+ *
+ * Sets `data-density` on <html> synchronously. The CSS variants in
+ * tailwind.css match `[data-density="..."] *`, so every descendant picks
+ * up the right spacing/visibility at first paint.
  */
 
 function initDensity(): void {
   const storedDensityMode = localStorage.getItem("densityMode") ?? "auto";
 
-  // Determine actual density to apply
   const determineDensity = (): string => {
     const isTouch = window.matchMedia("(pointer: coarse)").matches;
     const highContrast = window.matchMedia("(prefers-contrast: more)").matches;
@@ -15,25 +18,10 @@ function initDensity(): void {
 
   const actualDensity = storedDensityMode === "auto" ? determineDensity() : storedDensityMode;
 
-  // Apply to HTML element for global CSS variants
-  if (actualDensity === "compact") {
-    document.documentElement.classList.add("compact");
-  } else {
-    document.documentElement.classList.remove("compact");
-  }
-
-  // Apply to page-card container for density-variant classes
-  // Wait for DOM to be ready before querying elements
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => {
-      const pageCard = document.querySelector<HTMLDivElement>("div[data-density]");
-      if (pageCard?.dataset) pageCard.dataset["density"] = actualDensity;
-    });
-  } else {
-    const pageCard = document.querySelector<HTMLDivElement>("div[data-density]");
-    if (pageCard?.dataset) pageCard.dataset["density"] = actualDensity;
-  }
+  // Single source of truth: <html data-density="...">
+  document.documentElement.dataset["density"] = actualDensity;
+  // Kept for any selectors that key off the class (none currently, but cheap).
+  document.documentElement.classList.toggle("compact", actualDensity === "compact");
 }
 
-// Run immediately (before DOMContentLoaded to prevent layout shift)
 initDensity();

--- a/internal/web/static/js/error-utils.ts
+++ b/internal/web/static/js/error-utils.ts
@@ -30,25 +30,86 @@ export function createErrorElement(errorMessage: string): HTMLParagraphElement {
   return el;
 }
 
+/** One entry in the error summary — a field and its first error message. */
+export interface FieldError {
+  fieldId: string; // id of the <input>, used as the anchor target
+  label: string;
+  error: string;
+}
+
 /**
- * Updates error summary visibility and focus (WCAG 3.3.6)
+ * Updates error summary visibility, content and focus (WCAG 3.3.6).
+ * When errors exist, renders a linked list (<ol> of anchor links) so users
+ * can jump directly to the broken field.
  */
 export function updateErrorSummary(
   errorSummary: HTMLElement,
   errorSummaryText: HTMLElement,
-  errorCount: number,
+  fieldErrors: FieldError[],
   focusOnErrors: boolean
 ): void {
-  if (errorCount > 0) {
-    const fieldWord = errorCount === 1 ? "field" : "fields";
-    errorSummaryText.textContent = `Please correct ${errorCount.toString()} ${fieldWord} with errors below`;
-    errorSummary.classList.remove("hidden");
-    if (focusOnErrors) {
-      // Move focus to error summary for screen readers (WCAG 3.3.6)
-      errorSummary.focus();
-    }
-  } else {
+  const errorCount = fieldErrors.length;
+
+  if (errorCount === 0) {
     errorSummary.classList.add("hidden");
+    return;
+  }
+
+  const fieldWord = errorCount === 1 ? "field" : "fields";
+  errorSummaryText.textContent = `Please correct ${errorCount.toString()} ${fieldWord} below`;
+
+  let list = errorSummary.querySelector<HTMLOListElement>("ol[data-purpose='errorList']");
+  if (!list) {
+    list = document.createElement("ol");
+    list.dataset["purpose"] = "errorList";
+    list.className = "mt-2 ml-5 list-decimal space-y-1 text-sm text-error-dark dark:text-error-light";
+    errorSummary.appendChild(list);
+  }
+  while (list.firstChild) list.removeChild(list.firstChild);
+
+  for (const fe of fieldErrors) {
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = `#${fe.fieldId}`;
+    a.className = "underline hover:no-underline focus:ring-2 focus:ring-error-dark dark:focus:ring-error-light rounded";
+    a.textContent = `${fe.label}: ${fe.error}`;
+    a.addEventListener("click", (e) => {
+      e.preventDefault();
+      const target = document.getElementById(fe.fieldId);
+      if (target) {
+        target.focus();
+        target.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+    });
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+
+  errorSummary.classList.remove("hidden");
+  if (focusOnErrors) errorSummary.focus();
+}
+
+/**
+ * Render a server/submit error using the shared error element, so the visual
+ * matches the inline field errors (icon + text).
+ */
+export function setSubmitError(container: HTMLElement, message: string): void {
+  while (container.firstChild) container.removeChild(container.firstChild);
+  if (message) container.appendChild(createErrorElement(message));
+}
+
+/**
+ * Toggle red border + aria-invalid without rendering inline error text.
+ * Used when error text is surfaced elsewhere (e.g. the live password-policy
+ * checklist takes over the new_password text channel).
+ */
+export function setFieldInvalidStyle(inputContainer: HTMLElement, input: HTMLInputElement, invalid: boolean): void {
+  if (invalid) {
+    inputContainer.classList.add("!border-error-dark", "dark:!border-error-light");
+    input.setAttribute("aria-invalid", "true");
+  } else {
+    inputContainer.classList.remove("!border-error-dark", "dark:!border-error-light");
+    input.setAttribute("aria-invalid", "false");
   }
 }
 
@@ -66,13 +127,7 @@ export function setFieldErrors(
     errorContainer.removeChild(errorContainer.firstChild);
   }
 
-  if (errors.length > 0) {
-    inputContainer.classList.add("!border-error-dark", "dark:!border-error-light");
-    input.setAttribute("aria-invalid", "true");
-  } else {
-    inputContainer.classList.remove("!border-error-dark", "dark:!border-error-light");
-    input.setAttribute("aria-invalid", "false");
-  }
+  setFieldInvalidStyle(inputContainer, input, errors.length > 0);
 
   for (const error of errors) {
     errorContainer.appendChild(createErrorElement(error));

--- a/internal/web/static/js/error-utils.ts
+++ b/internal/web/static/js/error-utils.ts
@@ -78,7 +78,9 @@ export function updateErrorSummary(
       const target = document.getElementById(fe.fieldId);
       if (target) {
         target.focus();
-        target.scrollIntoView({ block: "center", behavior: "smooth" });
+        // Respect prefers-reduced-motion (WCAG 2.3.3).
+        const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        target.scrollIntoView({ block: "center", behavior: prefersReducedMotion ? "auto" : "smooth" });
       }
     });
     li.appendChild(a);

--- a/internal/web/static/js/forgot-password.ts
+++ b/internal/web/static/js/forgot-password.ts
@@ -18,11 +18,13 @@ export const init = () => {
   const errorSummaryText = errorSummary.querySelector<HTMLSpanElement>("span[data-purpose='summaryText']");
   if (!errorSummaryText) throw new Error("Could not find error summary text element");
 
-  const submitButton = form.querySelector<HTMLButtonElement>("& > div[data-purpose='submit'] > button[type='submit']");
+  const submitButton = form.querySelector<HTMLButtonElement>(
+    ":scope > div[data-purpose='submit'] > button[type='submit']"
+  );
   if (!submitButton) throw new Error("Could not find submit button element");
 
   const submitErrorContainer = form.querySelector<HTMLDivElement>(
-    "& > div[data-purpose='submit'] > div[data-purpose='errors']"
+    ":scope > div[data-purpose='submit'] > div[data-purpose='errors']"
   );
   if (!submitErrorContainer) throw new Error("Could not find submit error container element");
 
@@ -41,11 +43,10 @@ export const init = () => {
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
-    const getErrors = (): string[] =>
-      validators
-        .map((v) => v(getValue()))
-        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
-    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
+    const getErrors = (): string[] => validators.map((v) => v(getValue())).filter((msg) => msg.length > 0);
+    const paint = (errors: string[]) => {
+      setFieldErrors(errorContainer, inputContainer, input, errors);
+    };
 
     const helpButton = f.querySelector<HTMLButtonElement>('button[data-purpose="help"]');
     const helpText = f.querySelector<HTMLDivElement>('div[data-purpose="helpText"]');
@@ -106,7 +107,7 @@ export const init = () => {
     }
   });
 
-  form.addEventListener("submit", async (e) => {
+  const handleSubmit = async (e: SubmitEvent): Promise<void> => {
     e.preventDefault();
 
     for (const f of fields) {
@@ -148,5 +149,9 @@ export const init = () => {
       setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
     }
+  };
+
+  form.addEventListener("submit", (e) => {
+    void handleSubmit(e);
   });
 };

--- a/internal/web/static/js/forgot-password.ts
+++ b/internal/web/static/js/forgot-password.ts
@@ -1,9 +1,8 @@
 import { mustNotBeEmpty, isValidEmail } from "./validators.js";
 import { initThemeToggle, initDensityToggle } from "./toggles.js";
-import { setFieldErrors, updateErrorSummary } from "./error-utils.js";
+import { type FieldError, setFieldErrors, setSubmitError, updateErrorSummary } from "./error-utils.js";
 
 export const init = () => {
-  // Initialize theme and density toggles
   initThemeToggle();
   initDensityToggle();
 
@@ -27,134 +26,127 @@ export const init = () => {
   );
   if (!submitErrorContainer) throw new Error("Could not find submit error container element");
 
-  type Field = [string, ((v: string) => string)[]];
+  type Field = [string, string, ((v: string) => string)[]];
 
-  const fieldsWithValidators = [["email", [mustNotBeEmpty("Email"), isValidEmail]]] satisfies Field[];
+  const fieldsWithValidators = [["email", "Email Address", [mustNotBeEmpty("Email"), isValidEmail]]] satisfies Field[];
 
-  const fields = fieldsWithValidators.map(([name, validators]) => {
+  const fields = fieldsWithValidators.map(([name, label, validators]) => {
     const f = form.querySelector<HTMLDivElement>(`#${name}`);
     if (!f) throw new Error(`Field "${name}" does not exist`);
-
     const inputContainer = f.querySelector<HTMLDivElement>('div[data-purpose="inputContainer"]');
     if (!inputContainer) throw new Error(`Input container for "${name}" does not exist`);
-
     const input = inputContainer.querySelector<HTMLInputElement>("input");
     if (!input) throw new Error(`Input for "${name}" does not exist`);
-
     const errorContainer = f.querySelector<HTMLDivElement>('div[data-purpose="errors"]');
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
+    const getErrors = (): string[] =>
+      validators
+        .map((v) => v(getValue()))
+        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
+    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
 
-    const validate = () => {
-      const value = getValue();
-
-      const errors = validators
-        .map((validate) => validate(value))
-        .reduce<string[]>((acc, v) => {
-          if (v.length > 0) acc.push(v);
-
-          return acc;
-        }, []);
-
-      console.warn(`Validated "${name}": ${errors.length.toString()} error(s)`);
-
-      setFieldErrors(errorContainer, inputContainer, input, errors);
-
-      return errors.length > 0;
-    };
-
-    // Help toggle functionality
     const helpButton = f.querySelector<HTMLButtonElement>('button[data-purpose="help"]');
     const helpText = f.querySelector<HTMLDivElement>('div[data-purpose="helpText"]');
-
     if (helpButton && helpText) {
-      helpButton.onclick = (e) => {
+      helpButton.addEventListener("click", (e) => {
         e.preventDefault();
-        e.stopPropagation();
-
         const isExpanded = helpButton.getAttribute("aria-expanded") === "true";
         const newExpanded = !isExpanded;
-
         helpButton.setAttribute("aria-expanded", newExpanded.toString());
         helpText.classList.toggle("hidden", !newExpanded);
-      };
+      });
     }
 
-    return { input, errorContainer, getValue, validate };
+    return { name, label, input, getValue, getErrors, paint };
   });
 
-  const toggleFields = (enabled: boolean) => {
-    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => (el.disabled = !enabled));
-    submitButton.dataset["loading"] = (!enabled).toString();
+  const touched = new Set<string>();
+
+  const buildSummary = (): FieldError[] => {
+    const out: FieldError[] = [];
+    for (const f of fields) {
+      const errs = f.getErrors();
+      const first = errs[0];
+      if (first) out.push({ fieldId: f.input.id, label: f.label, error: first });
+    }
+    return out;
   };
 
-  form.onsubmit = async (e) => {
+  const toggleFields = (enabled: boolean) => {
+    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => {
+      el.disabled = !enabled;
+    });
+    submitButton.dataset["loading"] = (!enabled).toString();
+    submitButton.setAttribute("aria-busy", (!enabled).toString());
+  };
+
+  form.addEventListener(
+    "blur",
+    (e) => {
+      const target = e.target as HTMLElement;
+      const f = fields.find((x) => x.input === target);
+      if (!f) return;
+      touched.add(f.name);
+      f.paint(f.getErrors());
+      if (!errorSummary.classList.contains("hidden")) {
+        updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+      }
+    },
+    true
+  );
+
+  form.addEventListener("input", (e) => {
+    const target = e.target as HTMLElement;
+    const f = fields.find((x) => x.input === target);
+    if (f && touched.has(f.name)) f.paint(f.getErrors());
+    if (!errorSummary.classList.contains("hidden")) {
+      updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+    }
+  });
+
+  form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    e.stopPropagation();
+
+    for (const f of fields) {
+      touched.add(f.name);
+      f.paint(f.getErrors());
+    }
+
+    const summary = buildSummary();
+    updateErrorSummary(errorSummary, errorSummaryText, summary, true);
+    if (summary.length > 0) return;
+
+    setSubmitError(submitErrorContainer, "");
+    toggleFields(false);
 
     const [email] = fields.map((f) => f.getValue());
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, true); // Focus on submit attempt
-
-    if (hasErrors) return;
-
-    toggleFields(false);
 
     try {
       const res = await fetch("/api/rpc", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          method: "request-password-reset",
-          params: [email]
-        })
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ method: "request-password-reset", params: [email] })
       });
 
       const body = await res.text();
-
       if (!res.ok) {
         let err = body;
-
         try {
           const parsed = JSON.parse(body) as { data?: string[] };
-
           err = parsed.data?.[0] ?? body;
         } catch (_e) {
-          // Ignore JSON parsing errors, use body as-is
+          // use raw body
         }
-
-        throw new Error(`An error occurred: ${err}`);
+        throw new Error(err);
       }
 
-      form.style.display = "none";
-      successContainer.style.display = "block";
-    } catch (e) {
-      console.error(e);
-
-      submitErrorContainer.innerText = (e as Error).message;
-
-      // Re-enable inputs but keep the submit button disabled
+      form.classList.add("hidden");
+      successContainer.classList.remove("hidden");
+    } catch (err) {
+      setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
-      submitButton.disabled = true;
     }
-  };
-
-  form.onchange = (e) => {
-    e.stopPropagation();
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, false); // Don't focus on change
-  };
+  });
 };

--- a/internal/web/static/js/policy-ui.ts
+++ b/internal/web/static/js/policy-ui.ts
@@ -1,0 +1,99 @@
+/**
+ * Live password-policy checklist.
+ *
+ * Renders a <li> per rule inside the provided <ul>, then returns an
+ * `update(value)` function the caller invokes on every keystroke. On each
+ * call, the list items flip between "unmet" (neutral dot) and "met" (green
+ * check). Screen readers pick up the change via `aria-live="polite"` on the
+ * <ul> and the per-item `aria-label` that includes met/unmet status.
+ *
+ * SECURITY: SVG nodes are built via createElementNS — no innerHTML, no
+ * string concatenation. Rule labels reach the DOM via textContent.
+ */
+
+import type { PolicyRule } from "./validators.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function makeDotIcon(): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 20 20");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("class", "inline-block h-4 w-4 shrink-0");
+  const circle = document.createElementNS(SVG_NS, "circle");
+  circle.setAttribute("cx", "10");
+  circle.setAttribute("cy", "10");
+  circle.setAttribute("r", "3");
+  svg.appendChild(circle);
+  return svg;
+}
+
+function makeCheckIcon(): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 20 20");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("class", "inline-block h-4 w-4 shrink-0");
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("fill-rule", "evenodd");
+  path.setAttribute("clip-rule", "evenodd");
+  path.setAttribute(
+    "d",
+    "M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+  );
+  svg.appendChild(path);
+  return svg;
+}
+
+/**
+ * Render the policy list once. Returns an updater that toggles met/unmet
+ * state on each <li> based on the current input value.
+ */
+export function renderPolicyList(list: HTMLElement, rules: PolicyRule[]): (value: string) => void {
+  while (list.firstChild) list.removeChild(list.firstChild);
+
+  const items = rules.map((rule) => {
+    const li = document.createElement("li");
+    li.className = "flex items-center gap-2 transition-colors";
+    li.dataset["rule"] = rule.id;
+    li.dataset["met"] = "false";
+    li.setAttribute("aria-label", `${rule.label} — unmet`);
+
+    const iconWrap = document.createElement("span");
+    iconWrap.dataset["purpose"] = "icon";
+    iconWrap.className = "inline-flex text-gray-500 dark:text-gray-400";
+    iconWrap.appendChild(makeDotIcon());
+    li.appendChild(iconWrap);
+
+    const text = document.createElement("span");
+    text.textContent = rule.label;
+    li.appendChild(text);
+
+    list.appendChild(li);
+    return { li, iconWrap, rule };
+  });
+
+  return (value: string) => {
+    for (const { li, iconWrap, rule } of items) {
+      const met = rule.check(value);
+      const prevMet = li.dataset["met"] === "true";
+      if (met === prevMet) continue;
+
+      li.dataset["met"] = met.toString();
+      li.setAttribute("aria-label", `${rule.label} — ${met ? "met" : "unmet"}`);
+
+      // Color: green-800 on light / green-300 on dark meets WCAG AAA 7:1.
+      // Neutral gray for unmet (never red — unmet is not an error yet).
+      li.classList.toggle("text-green-800", met);
+      li.classList.toggle("dark:text-green-300", met);
+      iconWrap.classList.toggle("text-green-800", met);
+      iconWrap.classList.toggle("dark:text-green-300", met);
+      iconWrap.classList.toggle("text-gray-500", !met);
+      iconWrap.classList.toggle("dark:text-gray-400", !met);
+
+      while (iconWrap.firstChild) iconWrap.removeChild(iconWrap.firstChild);
+      iconWrap.appendChild(met ? makeCheckIcon() : makeDotIcon());
+    }
+  };
+}

--- a/internal/web/static/js/reset-password-init.ts
+++ b/internal/web/static/js/reset-password-init.ts
@@ -1,15 +1,15 @@
 /**
- * Reset password initialization wrapper - reads configuration from data attributes
- * for CSP compliance (no inline scripts)
+ * Reset password initialization wrapper — reads configuration from data
+ * attributes for CSP compliance (no inline scripts).
+ *
+ * NOTE: `document.currentScript` is ALWAYS null inside ES modules (per spec),
+ * so we look the script up explicitly by src.
  */
 
 import { init } from "./reset-password.js";
 
-// Get the current script element to read data attributes
-// Note: document.currentScript can be null in ES6 modules, so we provide fallback
-const currentScript = document.currentScript as HTMLScriptElement | null;
+const currentScript = document.querySelector<HTMLScriptElement>('script[src*="reset-password-init.js"]');
 
-// Read configuration from data attributes with defaults
 const config = {
   minLength: Number(currentScript?.dataset["minLength"] ?? "8"),
   minNumbers: Number(currentScript?.dataset["minNumbers"] ?? "0"),
@@ -18,5 +18,4 @@ const config = {
   minLowercase: Number(currentScript?.dataset["minLowercase"] ?? "0")
 };
 
-// Initialize with configuration (always call, even with defaults)
 init(config);

--- a/internal/web/static/js/reset-password.ts
+++ b/internal/web/static/js/reset-password.ts
@@ -42,11 +42,13 @@ export const init = (opts: Opts) => {
   const errorSummaryText = errorSummary.querySelector<HTMLSpanElement>("span[data-purpose='summaryText']");
   if (!errorSummaryText) throw new Error("Could not find error summary text element");
 
-  const submitButton = form.querySelector<HTMLButtonElement>("& > div[data-purpose='submit'] > button[type='submit']");
+  const submitButton = form.querySelector<HTMLButtonElement>(
+    ":scope > div[data-purpose='submit'] > button[type='submit']"
+  );
   if (!submitButton) throw new Error("Could not find submit button element");
 
   const submitErrorContainer = form.querySelector<HTMLDivElement>(
-    "& > div[data-purpose='submit'] > div[data-purpose='errors']"
+    ":scope > div[data-purpose='submit'] > div[data-purpose='errors']"
   );
   if (!submitErrorContainer) throw new Error("Could not find submit error container element");
 
@@ -97,11 +99,10 @@ export const init = (opts: Opts) => {
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
-    const getErrors = (): string[] =>
-      validators
-        .map((v) => v(getValue()))
-        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
-    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
+    const getErrors = (): string[] => validators.map((v) => v(getValue())).filter((msg) => msg.length > 0);
+    const paint = (errors: string[]) => {
+      setFieldErrors(errorContainer, inputContainer, input, errors);
+    };
     const paintBorderOnly = (invalid: boolean) => {
       while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
       setFieldInvalidStyle(inputContainer, input, invalid);
@@ -143,7 +144,9 @@ export const init = (opts: Opts) => {
   const policyUpdater = policyList && newPasswordField ? renderPolicyList(policyList, buildPolicyRules(opts)) : null;
   if (policyUpdater && newPasswordField) {
     policyUpdater(newPasswordField.getValue());
-    newPasswordField.paint = (errors) => newPasswordField.paintBorderOnly(errors.length > 0);
+    newPasswordField.paint = (errors) => {
+      newPasswordField.paintBorderOnly(errors.length > 0);
+    };
   }
 
   const touched = new Set<string>();
@@ -198,7 +201,7 @@ export const init = (opts: Opts) => {
     }
   });
 
-  form.addEventListener("submit", async (e) => {
+  const handleSubmit = async (e: SubmitEvent): Promise<void> => {
     e.preventDefault();
 
     for (const f of fields) {
@@ -240,5 +243,9 @@ export const init = (opts: Opts) => {
       setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
     }
+  };
+
+  form.addEventListener("submit", (e) => {
+    void handleSubmit(e);
   });
 };

--- a/internal/web/static/js/reset-password.ts
+++ b/internal/web/static/js/reset-password.ts
@@ -1,4 +1,5 @@
 import {
+  buildPolicyRules,
   mustBeLongerThan,
   mustIncludeLowercase,
   mustIncludeNumbers,
@@ -8,7 +9,14 @@ import {
   mustNotBeEmpty
 } from "./validators.js";
 import { initThemeToggle, initDensityToggle } from "./toggles.js";
-import { setFieldErrors, updateErrorSummary } from "./error-utils.js";
+import {
+  type FieldError,
+  setFieldErrors,
+  setFieldInvalidStyle,
+  setSubmitError,
+  updateErrorSummary
+} from "./error-utils.js";
+import { renderPolicyList } from "./policy-ui.js";
 
 interface Opts {
   minLength: number;
@@ -19,7 +27,6 @@ interface Opts {
 }
 
 export const init = (opts: Opts) => {
-  // Initialize theme and density toggles
   initThemeToggle();
   initDensityToggle();
 
@@ -43,22 +50,24 @@ export const init = (opts: Opts) => {
   );
   if (!submitErrorContainer) throw new Error("Could not find submit error container element");
 
-  // Extract token from URL
   const urlParams = new URLSearchParams(window.location.search);
   const token = urlParams.get("token");
 
   if (!token) {
-    submitErrorContainer.innerText =
-      "Unable to process your request. Please try again or request a new password reset link.";
+    setSubmitError(
+      submitErrorContainer,
+      "Unable to process your request. Please try again or request a new password reset link."
+    );
     submitButton.disabled = true;
     return;
   }
 
-  type Field = [string, ((v: string) => string)[]];
+  type Field = [string, string, ((v: string) => string)[]];
 
   const fieldsWithValidators = [
     [
       "new_password",
+      "New Password",
       [
         mustNotBeEmpty("New Password"),
         mustBeLongerThan(opts.minLength, "New Password"),
@@ -68,149 +77,168 @@ export const init = (opts: Opts) => {
         mustIncludeLowercase(opts.minLowercase, "New Password")
       ]
     ],
-    ["confirm_password", [mustNotBeEmpty("Confirm New Password"), mustMatchNewPassword("Confirm New Password")]]
+    [
+      "confirm_password",
+      "Confirm New Password",
+      [mustNotBeEmpty("Confirm New Password"), mustMatchNewPassword("Confirm New Password")]
+    ]
   ] satisfies Field[];
 
-  const fields = fieldsWithValidators.map(([name, validators]) => {
+  const fields = fieldsWithValidators.map(([name, label, validators]) => {
     const f = form.querySelector<HTMLDivElement>(`#${name}`);
     if (!f) throw new Error(`Field "${name}" does not exist`);
-
     const inputContainer = f.querySelector<HTMLDivElement>('div[data-purpose="inputContainer"]');
     if (!inputContainer) throw new Error(`Input container for "${name}" does not exist`);
-
     const input = inputContainer.querySelector<HTMLInputElement>("input");
     if (!input) throw new Error(`Input for "${name}" does not exist`);
-
     const revealButton = f.querySelector<HTMLButtonElement>('button[data-purpose="reveal"]');
     if (!revealButton && input.type === "password") throw new Error(`Reveal button for "${name}" does not exist`);
-
     const errorContainer = f.querySelector<HTMLDivElement>('div[data-purpose="errors"]');
     if (!errorContainer) throw new Error(`Error for "${name}" does not exist`);
 
     const getValue = () => input.value;
-
-    const validate = () => {
-      const value = getValue();
-
-      const errors = validators
-        .map((validate) => validate(value))
-        .reduce<string[]>((acc, v) => {
-          if (v.length > 0) acc.push(v);
-
-          return acc;
-        }, []);
-
-      console.warn(`Validated "${name}": ${errors.length.toString()} error(s)`);
-
-      setFieldErrors(errorContainer, inputContainer, input, errors);
-
-      return errors.length > 0;
+    const getErrors = (): string[] =>
+      validators
+        .map((v) => v(getValue()))
+        .reduce<string[]>((acc, msg) => (msg.length > 0 ? (acc.push(msg), acc) : acc), []);
+    const paint = (errors: string[]) => setFieldErrors(errorContainer, inputContainer, input, errors);
+    const paintBorderOnly = (invalid: boolean) => {
+      while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
+      setFieldInvalidStyle(inputContainer, input, invalid);
     };
 
     if (revealButton) {
-      revealButton.onclick = (e) => {
+      revealButton.addEventListener("click", (e) => {
         e.preventDefault();
-        e.stopPropagation();
-
         const newType = input.type === "password" ? "text" : "password";
         const revealed = newType === "text";
-
         input.type = newType;
         f.dataset["revealed"] = revealed.toString();
-      };
+        revealButton.setAttribute("aria-label", revealed ? "Hide password" : "Show password");
+        revealButton.setAttribute("aria-pressed", revealed.toString());
+      });
     }
 
-    // Help toggle functionality
     const helpButton = f.querySelector<HTMLButtonElement>('button[data-purpose="help"]');
     const helpText = f.querySelector<HTMLDivElement>('div[data-purpose="helpText"]');
-
     if (helpButton && helpText) {
-      helpButton.onclick = (e) => {
+      helpButton.addEventListener("click", (e) => {
         e.preventDefault();
-        e.stopPropagation();
-
         const isExpanded = helpButton.getAttribute("aria-expanded") === "true";
         const newExpanded = !isExpanded;
-
         helpButton.setAttribute("aria-expanded", newExpanded.toString());
         helpText.classList.toggle("hidden", !newExpanded);
-      };
+      });
     }
 
-    return { input, errorContainer, getValue, validate };
+    return { name, label, input, getValue, getErrors, paint, paintBorderOnly };
   });
 
-  const toggleFields = (enabled: boolean) => {
-    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => (el.disabled = !enabled));
-    submitButton.dataset["loading"] = (!enabled).toString();
+  // Live policy checklist tied to the New Password field. When present, it
+  // becomes the visual source of truth for password-rule violations — we
+  // suppress the field's inline error text so the user doesn't see the
+  // same rules twice (the red border + aria-invalid still flip on).
+  const policyList = document.querySelector<HTMLUListElement>("#password-policy");
+  const newPasswordField = fields.find((f) => f.name === "new_password");
+  const policyUpdater = policyList && newPasswordField ? renderPolicyList(policyList, buildPolicyRules(opts)) : null;
+  if (policyUpdater && newPasswordField) {
+    policyUpdater(newPasswordField.getValue());
+    newPasswordField.paint = (errors) => newPasswordField.paintBorderOnly(errors.length > 0);
+  }
+
+  const touched = new Set<string>();
+
+  const buildSummary = (): FieldError[] => {
+    const out: FieldError[] = [];
+    for (const f of fields) {
+      const errs = f.getErrors();
+      const first = errs[0];
+      if (first) out.push({ fieldId: f.input.id, label: f.label, error: first });
+    }
+    return out;
   };
 
-  form.onsubmit = async (e) => {
+  const toggleFields = (enabled: boolean) => {
+    [submitButton, ...fields.map(({ input }) => input)].forEach((el) => {
+      el.disabled = !enabled;
+    });
+    submitButton.dataset["loading"] = (!enabled).toString();
+    submitButton.setAttribute("aria-busy", (!enabled).toString());
+  };
+
+  form.addEventListener(
+    "blur",
+    (e) => {
+      const target = e.target as HTMLElement;
+      const f = fields.find((x) => x.input === target);
+      if (!f) return;
+      touched.add(f.name);
+      f.paint(f.getErrors());
+      if (!errorSummary.classList.contains("hidden")) {
+        updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+      }
+    },
+    true
+  );
+
+  form.addEventListener("input", (e) => {
+    if (policyUpdater && newPasswordField) policyUpdater(newPasswordField.getValue());
+
+    const target = e.target as HTMLElement;
+    const f = fields.find((x) => x.input === target);
+    if (f && touched.has(f.name)) f.paint(f.getErrors());
+
+    if (f?.name === "new_password") {
+      const confirm = fields.find((x) => x.name === "confirm_password");
+      if (confirm && touched.has("confirm_password")) confirm.paint(confirm.getErrors());
+    }
+
+    if (!errorSummary.classList.contains("hidden")) {
+      updateErrorSummary(errorSummary, errorSummaryText, buildSummary(), false);
+    }
+  });
+
+  form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    e.stopPropagation();
+
+    for (const f of fields) {
+      touched.add(f.name);
+      f.paint(f.getErrors());
+    }
+
+    const summary = buildSummary();
+    updateErrorSummary(errorSummary, errorSummaryText, summary, true);
+    if (summary.length > 0) return;
+
+    setSubmitError(submitErrorContainer, "");
+    toggleFields(false);
 
     const [newPassword] = fields.map((f) => f.getValue());
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, true); // Focus on submit attempt
-
-    if (hasErrors) return;
-
-    toggleFields(false);
 
     try {
       const res = await fetch("/api/rpc", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          method: "reset-password",
-          params: [token, newPassword]
-        })
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ method: "reset-password", params: [token, newPassword] })
       });
 
       const body = await res.text();
-
       if (!res.ok) {
         let err = body;
-
         try {
           const parsed = JSON.parse(body) as { data?: string[] };
-
           err = parsed.data?.[0] ?? body;
         } catch (_e) {
-          // Ignore JSON parsing errors, use body as-is
+          // use raw body
         }
-
-        throw new Error(`An error occurred: ${err}`);
+        throw new Error(err);
       }
 
-      form.style.display = "none";
-      successContainer.style.display = "block";
-    } catch (e) {
-      console.error(e);
-
-      submitErrorContainer.innerText = (e as Error).message;
-
-      // Re-enable inputs but keep the submit button disabled
+      form.classList.add("hidden");
+      successContainer.classList.remove("hidden");
+    } catch (err) {
+      setSubmitError(submitErrorContainer, (err as Error).message);
       toggleFields(true);
-      submitButton.disabled = true;
     }
-  };
-
-  form.onchange = (e) => {
-    e.stopPropagation();
-
-    const fieldErrors = fields.map(({ validate }) => validate());
-    const hasErrors = fieldErrors.some((e) => e);
-    const errorCount = fieldErrors.filter((e) => e).length;
-
-    submitButton.disabled = hasErrors;
-    updateErrorSummary(errorSummary, errorSummaryText, errorCount, false); // Don't focus on change
-  };
+  });
 };

--- a/internal/web/static/js/toggles.ts
+++ b/internal/web/static/js/toggles.ts
@@ -33,10 +33,9 @@ export const initThemeToggle = () => {
         dark: "Dark mode",
         auto: "Auto mode (follows system preference)"
       };
-      themeToggle.setAttribute(
-        "aria-label",
-        `Theme: ${themeLabels[theme]}. Click to switch to ${themeLabels[nextTheme]}`
-      );
+      const themeMessage = `Theme: ${themeLabels[theme]}. Click to switch to ${themeLabels[nextTheme]}`;
+      themeToggle.setAttribute("aria-label", themeMessage);
+      themeToggle.title = themeMessage; // sighted-user tooltip on hover
 
       // Apply theme
       if (theme === "light") {
@@ -74,9 +73,8 @@ export const initDensityToggle = () => {
   const densityComfortableIcon = document.getElementById("density-comfortable");
   const densityCompactIcon = document.getElementById("density-compact");
   const densityAutoIcon = document.getElementById("density-auto");
-  const mainContainer = document.querySelector<HTMLDivElement>("div[data-density]");
 
-  if (densityToggle && densityComfortableIcon && densityCompactIcon && densityAutoIcon && mainContainer) {
+  if (densityToggle && densityComfortableIcon && densityCompactIcon && densityAutoIcon) {
     // Determine appropriate density based on system preferences
     const determineDensityFromPreferences = (): DensityState => {
       const isTouch = window.matchMedia("(pointer: coarse)").matches;
@@ -98,14 +96,11 @@ export const initDensityToggle = () => {
       // Determine actual state to apply
       const actualState: DensityState = mode === "auto" ? determineDensityFromPreferences() : mode;
 
-      // Apply to main container (this triggers all density-variant classes)
-      mainContainer.dataset["density"] = actualState;
-
-      // Apply to html element (this triggers all density-variant classes)
-      document.documentElement.classList.remove("compact");
-      if (actualState === "compact") {
-        document.documentElement.classList.add("compact");
-      }
+      // Single source of truth: <html data-density="..."> — the `comfortable`
+      // / `compact` variants in tailwind.css key off this attribute and cascade
+      // to every descendant.
+      document.documentElement.dataset["density"] = actualState;
+      document.documentElement.classList.toggle("compact", actualState === "compact");
 
       // Update icon visibility (show only current mode's icon)
       densityComfortableIcon.classList.toggle("hidden", mode !== "comfortable");
@@ -121,10 +116,9 @@ export const initDensityToggle = () => {
 
       const nextMode: DensityMode = mode === "auto" ? "comfortable" : mode === "comfortable" ? "compact" : "auto";
 
-      densityToggle.setAttribute(
-        "aria-label",
-        `Density: ${modeLabels[mode]}. Click to switch to ${modeLabels[nextMode]}`
-      );
+      const densityMessage = `Density: ${modeLabels[mode]}. Click to switch to ${modeLabels[nextMode]}`;
+      densityToggle.setAttribute("aria-label", densityMessage);
+      densityToggle.title = densityMessage; // sighted-user tooltip on hover
     };
 
     // Initialize on page load

--- a/internal/web/static/js/validators.ts
+++ b/internal/web/static/js/validators.ts
@@ -68,7 +68,7 @@ export const mustBeLongerThan = (minLength: number, fieldName: string) => (v: st
  * validator("abc12"); // Returns: ""
  */
 export const mustIncludeNumbers = (amount: number, fieldName: string) => (v: string) =>
-  v.split("").filter((c) => !isNaN(+c)).length < amount
+  (v.match(/\d/g) ?? []).length < amount
     ? `${fieldName} must include at least ${amount.toString()} ${pluralize("number", amount)}`
     : "";
 
@@ -247,7 +247,7 @@ export const buildPolicyRules = (opts: PolicyOpts): PolicyRule[] => {
     rules.push({
       id: "numbers",
       label: `At least ${opts.minNumbers.toString()} ${pluralize("number", opts.minNumbers)}`,
-      check: (v) => v.split("").filter((c) => !isNaN(+c)).length >= opts.minNumbers
+      check: (v) => (v.match(/\d/g) ?? []).length >= opts.minNumbers
     });
   }
   if (opts.minSymbols > 0) {

--- a/internal/web/static/js/validators.ts
+++ b/internal/web/static/js/validators.ts
@@ -204,7 +204,74 @@ export const toggleValidator = (validate: (v: string) => string, enabled: boolea
  * isValidEmail("user+tag@sub.example.co.uk"); // Returns: ""
  */
 export const isValidEmail = (v: string) => {
-  // RFC 5322 compliant email regex (simplified but comprehensive)
+  // Simplified email regex — covers the common cases. Not full RFC 5322
+  // (no IDN, no quoted local parts). Good enough for LDAP deployments;
+  // the browser's native type="email" parser runs alongside it.
   const emailRegex = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,63}$/;
   return !emailRegex.test(v) ? "The input must be a valid email address" : "";
+};
+
+/**
+ * A single password-policy rule, used by the live checklist under the
+ * New Password field. Each rule has a stable id (for DOM keying), a
+ * human-readable label, and a check predicate.
+ */
+export interface PolicyRule {
+  id: string;
+  label: string;
+  check: (value: string) => boolean;
+}
+
+export interface PolicyOpts {
+  minLength: number;
+  minNumbers: number;
+  minSymbols: number;
+  minUppercase: number;
+  minLowercase: number;
+}
+
+/**
+ * Build the list of policy rules from the server-provided options.
+ * Rules with a `min*` of 0 are omitted (nothing to satisfy).
+ * The length rule is always present (minLength defaults to 8).
+ */
+export const buildPolicyRules = (opts: PolicyOpts): PolicyRule[] => {
+  const rules: PolicyRule[] = [
+    {
+      id: "length",
+      label: `At least ${opts.minLength.toString()} ${pluralize("character", opts.minLength)}`,
+      check: (v) => v.length >= opts.minLength
+    }
+  ];
+  if (opts.minNumbers > 0) {
+    rules.push({
+      id: "numbers",
+      label: `At least ${opts.minNumbers.toString()} ${pluralize("number", opts.minNumbers)}`,
+      check: (v) => v.split("").filter((c) => !isNaN(+c)).length >= opts.minNumbers
+    });
+  }
+  if (opts.minSymbols > 0) {
+    rules.push({
+      id: "symbols",
+      label: `At least ${opts.minSymbols.toString()} special ${pluralize("character", opts.minSymbols)} (e.g. !, @, #, $)`,
+      check: (v) => v.split("").filter((c) => specialCharacters.includes(c)).length >= opts.minSymbols
+    });
+  }
+  if (opts.minUppercase > 0) {
+    rules.push({
+      id: "uppercase",
+      label: `At least ${opts.minUppercase.toString()} uppercase ${pluralize("character", opts.minUppercase)}`,
+      check: (v) =>
+        v.split("").filter((c) => c === c.toUpperCase() && c !== c.toLowerCase()).length >= opts.minUppercase
+    });
+  }
+  if (opts.minLowercase > 0) {
+    rules.push({
+      id: "lowercase",
+      label: `At least ${opts.minLowercase.toString()} lowercase ${pluralize("character", opts.minLowercase)}`,
+      check: (v) =>
+        v.split("").filter((c) => c === c.toLowerCase() && c !== c.toUpperCase()).length >= opts.minLowercase
+    });
+  }
+  return rules;
 };

--- a/internal/web/tailwind.css
+++ b/internal/web/tailwind.css
@@ -49,7 +49,8 @@
 @custom-variant error-input-focus (&:has(input[aria-invalid="true"]:focus));
 
 /* Custom variants for UI density toggle */
-/* Matches both the container AND its descendants */
+/* Matches the container AND its descendants. density-init.ts sets
+ * data-density on <html> synchronously, so first paint is correct (no FOUC). */
 @custom-variant comfortable (&:is([data-density="comfortable"], [data-density="comfortable"] *));
 @custom-variant compact (&:is([data-density="compact"], [data-density="compact"] *));
 

--- a/internal/web/templates/forgot-password.html
+++ b/internal/web/templates/forgot-password.html
@@ -7,7 +7,7 @@
   </head>
 
   <body class="page-body">
-    <div class="page-card" data-density="comfortable">
+    <div class="page-card">
       {{ template "page-header" }}
 
       <main role="main">

--- a/internal/web/templates/forgot-password.html
+++ b/internal/web/templates/forgot-password.html
@@ -29,7 +29,7 @@
             </p>
           </div>
           <!-- prettier-ignore -->
-          {{ template "input" InputOpts "email" "Email Address" "text" "email" "Enter your email address to receive a password reset link" }}
+          {{ template "input" InputOpts "email" "Email Address" "email" "email" "Enter your email address to receive a password reset link" }}
 
           {{ template "form-submit" "Send Reset Link" }}
         </form>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -32,7 +32,14 @@
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "current_password" "Current Password" "password" "current-password" "Enter your current password to verify your identity" }}
           <!-- prettier-ignore -->
-          {{ template "input" InputOpts "new_password" "New Password" "password" "new-password" "Your new password must be strong and meet all security requirements shown below when you start typing" }}
+          {{ template "input" InputOpts "new_password" "New Password" "password" "new-password" "Your new password must satisfy all the requirements listed below." }}
+          <ul
+            id="password-policy"
+            class="comfortable:text-sm compact:text-xs text-gray-800 dark:text-gray-200 space-y-1"
+            aria-label="Password requirements"
+            aria-live="polite"
+            data-purpose="policy"
+          ></ul>
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "confirm_password" "Confirm New Password" "password" "new-password" "Re-enter your new password to confirm" }}
 

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body class="page-body">
-    <div class="page-card" data-density="comfortable">
+    <div class="page-card">
       {{ template "page-header" }}
 
       <main role="main">

--- a/internal/web/templates/molecules/input-field.html
+++ b/internal/web/templates/molecules/input-field.html
@@ -7,31 +7,29 @@
   <div class="flex items-center gap-1">
     <label
       for="input-{{ .Name }}"
-      class="comfortable:block compact:sr-only text-xs font-semibold text-gray-900 uppercase dark:text-gray-100"
+      class="comfortable:text-xs compact:text-[11px] block font-semibold text-gray-900 uppercase dark:text-gray-100"
     >
       {{ .Placeholder }}
     </label>
     {{ if .Help }}
-    <div class="comfortable:contents compact:hidden">
-      <button
-        type="button"
-        class="rounded-sm p-2.5 text-gray-500 outline-none hover:text-gray-700 focus:ring-2 focus:ring-gray-900 dark:text-gray-400 dark:hover:text-gray-300 dark:focus:ring-gray-300"
-        data-purpose="help"
-        aria-label="Help for {{ .Placeholder }}"
-        aria-expanded="false"
-        aria-controls="help-{{ .Name }}"
-      >
-        <!-- prettier-ignore -->
-        {{ template "HelpIcon" }}
-      </button>
-    </div>
+    <button
+      type="button"
+      class="comfortable:p-2.5 compact:p-1.5 rounded-sm text-gray-500 outline-none hover:text-gray-700 focus:ring-2 focus:ring-gray-900 dark:text-gray-400 dark:hover:text-gray-300 dark:focus:ring-gray-300"
+      data-purpose="help"
+      aria-label="Help for {{ .Placeholder }}"
+      aria-expanded="false"
+      aria-controls="help-{{ .Name }}"
+    >
+      <!-- prettier-ignore -->
+      {{ template "HelpIcon" }}
+    </button>
     {{ end }}
   </div>
 
   {{ if .Help }}
   <div
     id="help-{{ .Name }}"
-    class="hidden rounded-md bg-gray-100 p-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+    class="hidden rounded-md bg-gray-100 p-2 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200"
     data-purpose="helpText"
     role="region"
     aria-live="polite"
@@ -59,6 +57,7 @@
       <input
         id="input-{{ .Name }}"
         type="{{ .Type }}"
+        {{ if eq .Type "email" }}inputmode="email"{{ end }}
         name="{{ .Name }}"
         placeholder="{{ .Placeholder }}"
         autocomplete="{{ .Autocomplete }}"

--- a/internal/web/templates/molecules/page-footer.html
+++ b/internal/web/templates/molecules/page-footer.html
@@ -1,5 +1,5 @@
 {{ define "page-footer" }}
-<footer role="contentinfo" class="mt-auto pt-8 border-t border-gray-200 dark:border-gray-700">
+<footer role="contentinfo" class="pt-8 border-t border-gray-200 dark:border-gray-700">
   <p class="flex items-center justify-center gap-1 comfortable:text-sm compact:text-xs text-gray-500 dark:text-gray-400">
     <span>Built by {{ template "link" (slice "https://www.netresearch.de/" "Netresearch DTT GmbH") }} —</span>
     <a

--- a/internal/web/templates/molecules/page-header.html
+++ b/internal/web/templates/molecules/page-header.html
@@ -7,7 +7,7 @@
       class="comfortable:h-28 comfortable:w-28 comfortable:sm:h-48 comfortable:sm:w-48 compact:h-24 compact:w-24 compact:sm:h-32 compact:sm:w-32 aspect-square"
       alt=""
     />
-    <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">GopherPass</h1>
+    <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100" aria-label="GopherPass">GopherPass</p>
   </div>
 </header>
 {{ end }}

--- a/internal/web/templates/molecules/page-title.html
+++ b/internal/web/templates/molecules/page-title.html
@@ -1,10 +1,10 @@
 {{ define "page-title" }}
-<h1 class="comfortable:block compact:sr-only text-center text-2xl font-semibold text-gray-900 dark:text-gray-100">
+<h1 class="comfortable:text-2xl compact:text-lg text-center font-semibold text-gray-900 dark:text-gray-100">
   {{ index . 0 }}
 </h1>
 
 {{ if gt (len .) 1 }}
-<p class="comfortable:block compact:sr-only text-center text-sm text-gray-500 dark:text-gray-400">{{ index . 1 }}</p>
+<p class="comfortable:text-sm compact:text-xs text-center text-gray-700 dark:text-gray-300">{{ index . 1 }}</p>
 {{ end }} {{ if gt (len .) 2 }}
 <h2 class="sr-only">{{ index . 2 }}</h2>
 {{ end }} {{ end }}

--- a/internal/web/templates/molecules/toggle-buttons.html
+++ b/internal/web/templates/molecules/toggle-buttons.html
@@ -1,25 +1,27 @@
 {{ define "toggle-buttons" }}
-<button
-  type="button"
-  id="densityToggle"
-  class="comfortable:h-10 comfortable:p-2 compact:h-9 compact:p-1.5 absolute top-4 right-16 rounded-md border-2 border-gray-300 text-gray-600 outline-none hover:bg-gray-100 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-gray-400 dark:text-gray-400 dark:hover:bg-gray-800 dark:focus:ring-gray-300 dark:focus:ring-offset-gray-900"
-  aria-label="Display density"
-  data-density-mode="auto"
->
-  <span id="density-comfortable" class="hidden">{{ template "Squares2x2Icon" }}</span>
-  <span id="density-compact" class="hidden">{{ template "SquaresPlusIcon" }}</span>
-  <span id="density-auto">{{ template "SparklesIcon" }}</span>
-</button>
+<div role="toolbar" aria-label="Display preferences" class="absolute top-4 right-4 flex gap-2">
+  <button
+    type="button"
+    id="densityToggle"
+    class="comfortable:h-10 comfortable:p-2 compact:h-9 compact:p-1.5 rounded-md border-2 border-gray-300 text-gray-600 outline-none hover:bg-gray-100 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-gray-400 dark:text-gray-400 dark:hover:bg-gray-800 dark:focus:ring-gray-300 dark:focus:ring-offset-gray-900"
+    aria-label="Display density"
+    data-density-mode="auto"
+  >
+    <span id="density-comfortable" class="hidden">{{ template "Squares2x2Icon" }}</span>
+    <span id="density-compact" class="hidden">{{ template "SquaresPlusIcon" }}</span>
+    <span id="density-auto">{{ template "SparklesIcon" }}</span>
+  </button>
 
-<button
-  type="button"
-  id="themeToggle"
-  class="comfortable:h-10 comfortable:p-2 compact:h-9 compact:p-1.5 absolute top-4 right-4 rounded-md border-2 border-gray-300 text-gray-600 outline-none hover:bg-gray-100 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-gray-400 dark:text-gray-400 dark:hover:bg-gray-800 dark:focus:ring-gray-300 dark:focus:ring-offset-gray-900"
-  aria-label="Theme"
-  data-theme="auto"
->
-  <span id="theme-light" class="hidden">{{ template "SunIcon" }}</span>
-  <span id="theme-dark" class="hidden">{{ template "MoonIcon" }}</span>
-  <span id="theme-auto">{{ template "ComputerIcon" }}</span>
-</button>
+  <button
+    type="button"
+    id="themeToggle"
+    class="comfortable:h-10 comfortable:p-2 compact:h-9 compact:p-1.5 rounded-md border-2 border-gray-300 text-gray-600 outline-none hover:bg-gray-100 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-gray-400 dark:text-gray-400 dark:hover:bg-gray-800 dark:focus:ring-gray-300 dark:focus:ring-offset-gray-900"
+    aria-label="Theme"
+    data-theme="auto"
+  >
+    <span id="theme-light" class="hidden">{{ template "SunIcon" }}</span>
+    <span id="theme-dark" class="hidden">{{ template "MoonIcon" }}</span>
+    <span id="theme-auto">{{ template "ComputerIcon" }}</span>
+  </button>
+</div>
 {{ end }}

--- a/internal/web/templates/reset-password.html
+++ b/internal/web/templates/reset-password.html
@@ -7,7 +7,7 @@
   </head>
 
   <body class="page-body">
-    <div class="page-card" data-density="comfortable">
+    <div class="page-card">
       {{ template "page-header" }}
 
       <main role="main">

--- a/internal/web/templates/reset-password.html
+++ b/internal/web/templates/reset-password.html
@@ -28,7 +28,14 @@
             </p>
           </div>
           <!-- prettier-ignore -->
-          {{ template "input" InputOpts "new_password" "New Password" "password" "new-password" "Your new password must be strong and meet all security requirements" }}
+          {{ template "input" InputOpts "new_password" "New Password" "password" "new-password" "Your new password must satisfy all the requirements listed below." }}
+          <ul
+            id="password-policy"
+            class="comfortable:text-sm compact:text-xs text-gray-800 dark:text-gray-200 space-y-1"
+            aria-label="Password requirements"
+            aria-live="polite"
+            data-purpose="policy"
+          ></ul>
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "confirm_password" "Confirm New Password" "password" "new-password" "Re-enter your new password to confirm" }}
 

--- a/internal/web/templates/templates.go
+++ b/internal/web/templates/templates.go
@@ -75,8 +75,8 @@ type InputOpts struct {
 
 // MakeInputOpts creates an InputOpts configuration for rendering form input fields.
 func MakeInputOpts(name, placeholder, inputType, autocomplete, help string) InputOpts {
-	if inputType != "password" && inputType != "text" {
-		panic("InputOpts type must be either `password` or `text`")
+	if inputType != "password" && inputType != "text" && inputType != "email" {
+		panic("InputOpts type must be one of `password`, `text`, or `email`")
 	}
 
 	return InputOpts{

--- a/internal/web/templates/templates_test.go
+++ b/internal/web/templates/templates_test.go
@@ -42,13 +42,13 @@ func TestMakeInputOpts(t *testing.T) {
 			wantPanic:    false,
 		},
 		{
-			name:         "invalid input type causes panic",
+			name:         "valid email input",
 			inputName:    "email",
 			placeholder:  "Email",
 			inputType:    "email",
 			autocomplete: "email",
 			help:         "Enter your email",
-			wantPanic:    true,
+			wantPanic:    false,
 		},
 		{
 			name:         "empty type causes panic",


### PR DESCRIPTION
## Description

Comprehensive UI/UX and accessibility pass on GopherPass, motivated by a design review focused on "keep it simple and unobtrusive, but helpful where needed, and WCAG 2.2 AAA". The work is split into **6 atomic commits** — each builds and passes tests independently.

One pre-existing bug was uncovered during Playwright testing and fixed as a standalone commit.

## Type of Change

- [x] 🐛 Bug fix (`document.currentScript` was always null in ES modules → server config never reached client)
- [x] ✨ New feature (live password-policy checklist)
- [x] ♻️ Refactoring (validation/error-handling flow)
- [x] 🎨 UI/UX improvement
- [ ] 💥 Breaking change
- [ ] 🔒 Security fix

## Commits

| SHA | Subject |
|-----|---------|
| [`d55bc3b`](../commit/d55bc3b) | `fix(js)`: load client config via explicit script selector |
| [`5164c9a`](../commit/5164c9a) | `feat(templates)`: allow "email" type in InputOpts helper |
| [`bf7f779`](../commit/bf7f779) | `a11y(ui)`: single h1, visible labels/title in compact, toolbar landmark |
| [`3e8688a`](../commit/3e8688a) | `fix(ui)`: eliminate density-mode FOUC by setting data-density on `<html>` |
| [`f4896a7`](../commit/f4896a7) | `feat(ui)`: live password-policy checklist + linked error summary |
| [`4d02d6a`](../commit/4d02d6a) | `chore(dev)`: add `cmd/uitest` browser-test server + ignore `.playwright-mcp` |

## Changes Made

**Pre-existing bug fixed** (`d55bc3b`)
- `document.currentScript` is `null` inside ES modules per spec, so `app-init.ts` and `reset-password-init.ts` were reading defaults (`minLength: 8`, every other `min*: 0`) regardless of `MIN_LENGTH` / `MIN_NUMBERS` / etc. configured on the server. Fixed via explicit `querySelector('script[src*="app-init.js"]')`.

**a11y / WCAG 2.2 AAA** (`bf7f779`, `3e8688a`)
- Single `<h1>` per page (brand demoted to `<p>`)
- Page title + field labels + help buttons stay visible in compact mode (were `sr-only` / `hidden` before — NN/g anti-pattern)
- Display-preferences toggles wrapped in `<div role="toolbar">` with explicit grouping
- Subtitle contrast raised to AAA (gray-700/gray-300)
- Density flash (FOUC) eliminated by setting `data-density` on `<html>` synchronously
- `<title>` mirrors `aria-label` on toggle buttons for sighted hover tooltips

**Password UX** (`f4896a7`)
- **Live policy checklist** under the New Password field. Each rule flips between a neutral gray dot (unmet) and an AAA-contrast green check (met) as the user types. `aria-live="polite"` + per-item `aria-label`.
- **Linked error summary** — clicking an entry focuses + scrolls to the broken field (WCAG 3.3.1).
- **Submit button stays enabled** on validation errors (was disabled — NN/g anti-pattern).
- **Touched-field tracking** — untouched fields aren't pre-painted red on first keystroke.
- **De-duplication** — when the policy checklist is present for `new_password`, its inline error text is suppressed (the checklist IS the channel); red border + `aria-invalid` still flip on.
- **Unified error styling** — server/submit errors use the same icon+text element as inline errors, not raw `innerText`.
- **Class toggles** replace `style.display` juggling (proper use of the existing `hidden` utility).
- **No PII logging** — stray `console.warn` debug log removed.

**Forms** (`5164c9a`, part of `bf7f779`)
- `InputOpts` now whitelists `"email"` (alongside `password`/`text`); forgot-password's email field uses `type="email"` + `inputmode="email"` — native mobile keyboard + browser-level validation.

**Dev tooling** (`4d02d6a`)
- `cmd/uitest/main.go` — behind the `uitest` build tag, renders real templates + static assets without LDAP/SMTP. Run via `go run -tags=uitest ./cmd/uitest`.
- `.playwright-mcp/` ignored in git + prettier.

## Testing

### Test Environment

- OS: Linux (WSL2, Ubuntu)
- Go version: 1.26
- Browser: Chromium (via Playwright MCP) @ 1440×900

### Test Cases

- [x] `go test -race ./...` — all packages green (including updated `templates_test.go`)
- [x] `bun run js:build` — clean under ultra-strict TypeScript
- [x] `bun run css:build` — Tailwind output regenerated
- [x] `bunx prettier --check .` — all formatted
- [x] `go build ./...` — clean
- [x] **Manual browser verification** with Playwright at 1440×900:
  - Initial render layout ✓
  - Policy list loads 5 server-configured rules ✓
  - Typing `Abc12` flips numbers/uppercase/lowercase to green ✓
  - `aria-label` updates per item (`"— met"` / `"— unmet"`) ✓
  - Empty submit → linked error summary shows 4 numbered anchor links, one per field ✓
  - Submit button stays enabled ✓
  - Field red borders + `aria-invalid="true"` ✓

### What wasn't live-verified

`setFieldInvalidStyle` was added in this PR; Playwright's per-session module cache pinned `error-utils.js` to its pre-patch version once loaded, so the "suppress inline errors for new_password" path couldn't be exercised via dynamic re-import in the same session. Verified via compiled-JS grep + static review instead. A fresh user gets a consistent module graph.

## Code Quality Checklist

- [x] Code follows the project's style guidelines
- [x] TypeScript strict checks pass (`bun run js:build`)
- [x] Prettier formatting applied
- [x] `go test ./...` passes

## Screenshots

Before | After
--- | ---
(policy only implicit in error messages; compact hid labels/title; errors disabled the submit button) | Live policy checklist with AAA green/gray; linked error summary with focus-jump links; submit stays enabled; labels visible at all densities.

Full-page screenshots captured during testing are in `.playwright-mcp/` (gitignored).

## Deployment Notes

- [x] No database migrations required
- [x] No configuration changes required
- [x] No breaking API changes
- [x] Backward compatible

No env-var changes. No LDAP/SMTP behavior changes. Pure frontend + template + one test-update.

## Reviewer Guidelines

- **Focus**: `internal/web/static/js/app.ts` rewrite — especially the `paint` / `paintBorderOnly` override for new_password, and the `touched` set flow between `input` / `blur` / `submit` handlers. Same pattern in `reset-password.ts` and (simpler) `forgot-password.ts`.
- **Also worth a look**: `buildPolicyRules` in `validators.ts` (data-only metadata, no DOM), `renderPolicyList` in the new `policy-ui.ts` (SVG built via `createElementNS` — no `innerHTML`).
- **Known limitation**: policy-list rule messages and the per-field error-string messages share information but aren't derived from a single source. Kept them separate deliberately — error strings carry field-specific context (`"New Password must be at least 10 chars long"`) while the checklist label is concise (`"At least 10 characters"`).