### PR TITLE
chore(dev): self-contained docker stack — OpenLDAP + Mailpit

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,43 +1,43 @@
-# Example .env.local for development with Docker Compose and Mailhog
-# Copy this file to .env.local and adjust values for your environment
+# Optional local overrides for `docker compose --profile dev up`.
+#
+# The stack ships sensible dev defaults in compose.yml — OpenLDAP (seeded
+# users) + Mailpit (SMTP sink at http://localhost:8025). You usually don't
+# need a .env.local at all. This file is loaded AFTER the defaults, so any
+# value you uncomment wins.
 
-# LDAP Configuration (adjust for your test LDAP server)
-LDAP_SERVER=ldaps://ldap.example.com:636
-LDAP_IS_AD=true
-LDAP_BASE_DN=DC=example,DC=com
-LDAP_READONLY_USER=cn=readonly,dc=example,dc=com
-LDAP_READONLY_PASSWORD=readonly_password
+# --- Point at a different LDAP server ----------------------------------
+# LDAP_SERVER=ldaps://ldap.example.com:636
+# LDAP_IS_AD=true
+# LDAP_BASE_DN=DC=example,DC=com
+# LDAP_READONLY_USER=cn=readonly,dc=example,dc=com
+# LDAP_READONLY_PASSWORD=readonly_password
 
-# Optional: Dedicated reset account (recommended for production)
-LDAP_RESET_USER=cn=password-reset,dc=example,dc=com
-LDAP_RESET_PASSWORD=reset_password
+# --- Dedicated reset account (recommended for prod) --------------------
+# LDAP_RESET_USER=cn=password-reset,dc=example,dc=com
+# LDAP_RESET_PASSWORD=reset_password
 
-# Password Policy
-MIN_LENGTH=8
-MIN_NUMBERS=1
-MIN_SYMBOLS=1
-MIN_UPPERCASE=1
-MIN_LOWERCASE=1
-PASSWORD_CAN_INCLUDE_USERNAME=false
+# --- Password policy ---------------------------------------------------
+# MIN_LENGTH=10
+# MIN_NUMBERS=1
+# MIN_SYMBOLS=1
+# MIN_UPPERCASE=1
+# MIN_LOWERCASE=1
+# PASSWORD_CAN_INCLUDE_USERNAME=false
 
-# Password Reset Feature
-PASSWORD_RESET_ENABLED=true
-RESET_TOKEN_EXPIRY_MINUTES=15
-RESET_RATE_LIMIT_REQUESTS=3
-RESET_RATE_LIMIT_WINDOW_MINUTES=60
+# --- Reset feature -----------------------------------------------------
+# PASSWORD_RESET_ENABLED=true
+# RESET_TOKEN_EXPIRY_MINUTES=15
+# RESET_RATE_LIMIT_REQUESTS=3
+# RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
-# SMTP Configuration - Mailhog for development
-# Mailhog runs on mailhog:1025 when using Docker Compose with dev profile
-# Web UI available at http://localhost:8025
-SMTP_HOST=mailhog
-SMTP_PORT=1025
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_FROM_ADDRESS=noreply@localhost
-APP_BASE_URL=http://localhost:3000
+# --- SMTP (Mailpit by default — override for real SMTP) ----------------
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM_ADDRESS=noreply@example.com
+# APP_BASE_URL=http://localhost:3000
 
-# Docker Compose Configuration
-APP_PORT=3000
-MAILHOG_SMTP_PORT=1025
-MAILHOG_WEB_PORT=8025
-SSL_CERTS_PATH=/etc/ssl/certs
+# --- Port mapping overrides -------------------------------------------
+# APP_PORT=3000
+# MAILPIT_WEB_PORT=8025

--- a/compose.yml
+++ b/compose.yml
@@ -1,36 +1,156 @@
 services:
-  # Main application service
+  # OpenLDAP server with seeded dev users.
+  # Pattern borrowed from netresearch/ldap-manager dev stack.
+  openldap:
+    image: osixia/openldap:1.5.0
+    container_name: gopherpass-openldap
+    hostname: openldap
+    ports:
+      - "389:389"
+      - "636:636"
+    environment:
+      LDAP_LOG_LEVEL: "256"
+      LDAP_ORGANISATION: "Netresearch"
+      LDAP_DOMAIN: "netresearch.local"
+      LDAP_BASE_DN: "dc=netresearch,dc=local"
+      LDAP_ADMIN_PASSWORD: "admin"
+      LDAP_CONFIG_PASSWORD: "config"
+      LDAP_READONLY_USER: "true"
+      LDAP_READONLY_USER_USERNAME: "readonly"
+      LDAP_READONLY_USER_PASSWORD: "readonly"
+      LDAP_RFC2307BIS_SCHEMA: "false"
+      LDAP_BACKEND: "mdb"
+      LDAP_TLS: "true"
+      LDAP_TLS_CRT_FILENAME: "ldap.crt"
+      LDAP_TLS_KEY_FILENAME: "ldap.key"
+      LDAP_TLS_DH_PARAM_FILENAME: "dhparam.pem"
+      LDAP_TLS_CA_CRT_FILENAME: "ca.crt"
+      LDAP_TLS_ENFORCE: "false"
+      LDAP_TLS_CIPHER_SUITE: "SECURE256:-VERS-SSL3.0"
+      LDAP_TLS_PROTOCOL_MIN: "3.1"
+      LDAP_TLS_VERIFY_CLIENT: "demand"
+      LDAP_REPLICATION: "false"
+      KEEP_EXISTING_CONFIG: "false"
+      LDAP_REMOVE_CONFIG_AFTER_SETUP: "true"
+      LDAP_SSL_HELPER_PREFIX: "ldap"
+    volumes:
+      - ldap_data:/var/lib/ldap
+      - ldap_config:/etc/ldap/slapd.d
+      - ./dev/seed.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/seed.ldif:ro
+    command: --copy-service
+    networks:
+      - ldap-network
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'ldapsearch -x -H ldap://localhost -b "$$LDAP_BASE_DN" -D "cn=admin,$$LDAP_BASE_DN" -w "$$LDAP_ADMIN_PASSWORD" -LLL'
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    profiles:
+      - dev
+      - test
+
+  # Applies an ACL that lets each user change their own userPassword,
+  # mirroring Active Directory's default behavior. Runs once, then exits.
+  openldap-init:
+    image: osixia/openldap:1.5.0
+    entrypoint: /bin/bash
+    command: /setup-acl.sh ldap://openldap:389
+    volumes:
+      - ./dev/setup-acl.sh:/setup-acl.sh:ro
+    depends_on:
+      openldap:
+        condition: service_healthy
+    networks:
+      - ldap-network
+    profiles:
+      - dev
+      - test
+
+  # Mailpit — modern MailHog replacement. Captures SMTP for local testing.
+  # Web UI: http://localhost:8025   SMTP (internal): mailpit:1025
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: gopherpass-mailpit
+    ports:
+      - "${MAILPIT_WEB_PORT:-8025}:8025"
+    # SMTP port 1025 is only reachable on the docker network — not exposed.
+    environment:
+      MP_MAX_MESSAGES: "500"
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+    networks:
+      - ldap-network
+    restart: unless-stopped
+    profiles:
+      - dev
+      - test
+
+  # Main application. Rebuilt from local Dockerfile so it picks up the
+  # current branch's templates and JS.
   app:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: gopherpass-app
     ports:
       - "${APP_PORT:-3000}:3000"
+    # Dev defaults — hermetic, point at the services above. Override anything
+    # via .env.local if needed (loaded after these defaults).
+    environment:
+      # LDAP
+      LDAP_SERVER: "ldap://openldap:389"
+      LDAP_IS_AD: "false"
+      LDAP_BASE_DN: "dc=netresearch,dc=local"
+      LDAP_READONLY_USER: "cn=admin,dc=netresearch,dc=local"
+      LDAP_READONLY_PASSWORD: "admin"
+      LDAP_RESET_USER: "cn=admin,dc=netresearch,dc=local"
+      LDAP_RESET_PASSWORD: "admin"
+      # Password policy
+      MIN_LENGTH: "10"
+      MIN_NUMBERS: "1"
+      MIN_SYMBOLS: "1"
+      MIN_UPPERCASE: "1"
+      MIN_LOWERCASE: "1"
+      PASSWORD_CAN_INCLUDE_USERNAME: "false"
+      # Reset feature
+      PASSWORD_RESET_ENABLED: "true"
+      RESET_TOKEN_EXPIRY_MINUTES: "15"
+      RESET_RATE_LIMIT_REQUESTS: "10"
+      RESET_RATE_LIMIT_WINDOW_MINUTES: "60"
+      # SMTP → mailpit
+      SMTP_HOST: "mailpit"
+      SMTP_PORT: "1025"
+      SMTP_USERNAME: ""
+      SMTP_PASSWORD: ""
+      SMTP_FROM_ADDRESS: "noreply@netresearch.local"
+      APP_BASE_URL: "http://localhost:3000"
     env_file:
-      - .env # Defaults and documentation
-      - .env.local # Local overrides (loaded second, takes precedence)
-    volumes:
-      # Mount SSL certs if using self-signed LDAPS certificates
-      - ${SSL_CERTS_PATH:-/etc/ssl/certs}:/etc/ssl/certs:ro
+      # Optional local override. Compose v2 treats missing files as empty
+      # when `required: false` is set.
+      - path: .env.local
+        required: false
     depends_on:
-      - mailhog
+      openldap-init:
+        condition: service_completed_successfully
+      mailpit:
+        condition: service_started
+    networks:
+      - ldap-network
     profiles:
       - dev
       - test
-    networks:
-      - ldap-network
 
-  # Mailhog for email testing (dev/test only)
-  mailhog:
-    image: mailhog/mailhog:v1.0.1
-    ports:
-      - "${MAILHOG_WEB_PORT:-8025}:8025" # Web UI
-    # SMTP port 1025 only accessible within docker network, not exposed to host
-    profiles:
-      - dev
-      - test
-    networks:
-      - ldap-network
+volumes:
+  ldap_data:
+    driver: local
+  ldap_config:
+    driver: local
 
 networks:
   ldap-network:

--- a/compose.yml
+++ b/compose.yml
@@ -55,12 +55,18 @@ services:
       - dev
       - test
 
-  # Applies an ACL that lets each user change their own userPassword,
-  # mirroring Active Directory's default behavior. Runs once, then exits.
+  # Applies an ACL that lets each user change their own userPassword and
+  # grants the password-reset service account write access to reset others'
+  # passwords (mirrors Active Directory's admin-reset capability). Runs once.
   openldap-init:
     image: osixia/openldap:1.5.0
     entrypoint: /bin/bash
     command: /setup-acl.sh ldap://openldap:389
+    environment:
+      # Must match LDAP_CONFIG_PASSWORD on the openldap service.
+      LDAP_CONFIG_PASSWORD: "config"
+      LDAP_BASE_DN: "dc=netresearch,dc=local"
+      RESET_USER_DN: "uid=password-reset,ou=People,dc=netresearch,dc=local"
     volumes:
       - ./dev/setup-acl.sh:/setup-acl.sh:ro
     depends_on:
@@ -75,7 +81,9 @@ services:
   # Mailpit — modern MailHog replacement. Captures SMTP for local testing.
   # Web UI: http://localhost:8025   SMTP (internal): mailpit:1025
   mailpit:
-    image: axllent/mailpit:latest
+    # Pinned for a reproducible dev stack. Bump deliberately — Mailpit minor
+    # releases can change the SMTP/API surface.
+    image: axllent/mailpit:v1.29.7
     container_name: gopherpass-mailpit
     ports:
       - "${MAILPIT_WEB_PORT:-8025}:8025"
@@ -103,14 +111,14 @@ services:
     # Dev defaults — hermetic, point at the services above. Override anything
     # via .env.local if needed (loaded after these defaults).
     environment:
-      # LDAP
+      # LDAP — least-privilege accounts (reflects production wiring).
       LDAP_SERVER: "ldap://openldap:389"
       LDAP_IS_AD: "false"
       LDAP_BASE_DN: "dc=netresearch,dc=local"
-      LDAP_READONLY_USER: "cn=admin,dc=netresearch,dc=local"
-      LDAP_READONLY_PASSWORD: "admin"
-      LDAP_RESET_USER: "cn=admin,dc=netresearch,dc=local"
-      LDAP_RESET_PASSWORD: "admin"
+      LDAP_READONLY_USER: "cn=readonly,dc=netresearch,dc=local"
+      LDAP_READONLY_PASSWORD: "readonly"
+      LDAP_RESET_USER: "uid=password-reset,ou=People,dc=netresearch,dc=local"
+      LDAP_RESET_PASSWORD: "reset-password"
       # Password policy
       MIN_LENGTH: "10"
       MIN_NUMBERS: "1"
@@ -121,7 +129,8 @@ services:
       # Reset feature
       PASSWORD_RESET_ENABLED: "true"
       RESET_TOKEN_EXPIRY_MINUTES: "15"
-      RESET_RATE_LIMIT_REQUESTS: "10"
+      # Matches the default documented in AGENTS.md (3/hour/IP).
+      RESET_RATE_LIMIT_REQUESTS: "3"
       RESET_RATE_LIMIT_WINDOW_MINUTES: "60"
       # SMTP → mailpit
       SMTP_HOST: "mailpit"

--- a/dev/seed.ldif
+++ b/dev/seed.ldif
@@ -1,0 +1,64 @@
+dn: ou=People,dc=netresearch,dc=local
+objectClass: organizationalUnit
+ou: People
+
+dn: ou=Groups,dc=netresearch,dc=local
+objectClass: organizationalUnit
+ou: Groups
+
+# Service account used by GopherPass for password RESET (admin rights on userPassword).
+# In production this maps to LDAP_RESET_USER — give it only the permissions it needs.
+# For the dev stack the standard cn=admin bind already has full write access.
+dn: uid=password-reset,ou=People,dc=netresearch,dc=local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: password-reset
+sn: Reset
+givenName: Password
+cn: Password Reset Service
+displayName: Password Reset Service
+uidNumber: 2000
+gidNumber: 1000
+homeDirectory: /home/password-reset
+loginShell: /sbin/nologin
+mail: password-reset@netresearch.local
+userPassword: reset-password
+
+dn: uid=jdoe,ou=People,dc=netresearch,dc=local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: jdoe
+sn: Doe
+givenName: John
+cn: John Doe
+displayName: John Doe
+uidNumber: 1001
+gidNumber: 1000
+homeDirectory: /home/jdoe
+loginShell: /bin/bash
+mail: john.doe@netresearch.local
+userPassword: password
+
+dn: uid=jsmith,ou=People,dc=netresearch,dc=local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: jsmith
+sn: Smith
+givenName: Jane
+cn: Jane Smith
+displayName: Jane Smith
+uidNumber: 1002
+gidNumber: 1000
+homeDirectory: /home/jsmith
+loginShell: /bin/bash
+mail: jane.smith@netresearch.local
+userPassword: password
+
+dn: cn=developers,ou=Groups,dc=netresearch,dc=local
+objectClass: groupOfNames
+cn: developers
+member: uid=jdoe,ou=People,dc=netresearch,dc=local
+member: uid=jsmith,ou=People,dc=netresearch,dc=local

--- a/dev/setup-acl.sh
+++ b/dev/setup-acl.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-# Wait for OpenLDAP to be ready, then apply ACLs that let each user change
-# their own userPassword. Mirrors the AD default where users can change
-# their own password.
+# Wait for OpenLDAP to be ready, then apply ACLs:
+#   - each user can change their own userPassword (like the AD default)
+#   - the password-reset service account can write any user's userPassword
+#     (mirrors AD's admin-driven reset capability)
+#   - authenticated users can read everything else
 #
-# Patterned after netresearch/ldap-manager dev stack.
-set -e
+# Config is read from environment so compose.yml stays the single source of
+# truth. Patterned after netresearch/ldap-manager's dev stack.
+set -euo pipefail
 
 LDAP_HOST="${1:-ldap://openldap:389}"
+LDAP_CONFIG_PASSWORD="${LDAP_CONFIG_PASSWORD:-config}"
+RESET_USER_DN="${RESET_USER_DN:-uid=password-reset,ou=People,dc=netresearch,dc=local}"
 MAX_RETRIES=30
 
 echo "Waiting for OpenLDAP at $LDAP_HOST..."
@@ -23,11 +28,15 @@ for i in $(seq 1 $MAX_RETRIES); do
 done
 
 echo "Applying ACLs..."
-ldapmodify -H "$LDAP_HOST" -D "cn=admin,cn=config" -w config <<'EOF'
+# Heredoc is unquoted so $RESET_USER_DN is interpolated. The rule order is
+# preserved: {0} userPassword rule, then {1} general read. Using `replace:`
+# (vs `add:`) guarantees a deterministic ACL regardless of whatever default
+# rules the openldap image ships — matching ldap-manager's pattern.
+ldapmodify -H "$LDAP_HOST" -D "cn=admin,cn=config" -w "$LDAP_CONFIG_PASSWORD" <<EOF
 dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 replace: olcAccess
-olcAccess: {0}to attrs=userPassword by self write by anonymous auth by * none
+olcAccess: {0}to attrs=userPassword by self write by dn.exact="$RESET_USER_DN" write by anonymous auth by * none
 olcAccess: {1}to * by users read by * none
 EOF
 

--- a/dev/setup-acl.sh
+++ b/dev/setup-acl.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Wait for OpenLDAP to be ready, then apply ACLs that let each user change
+# their own userPassword. Mirrors the AD default where users can change
+# their own password.
+#
+# Patterned after netresearch/ldap-manager dev stack.
+set -e
+
+LDAP_HOST="${1:-ldap://openldap:389}"
+MAX_RETRIES=30
+
+echo "Waiting for OpenLDAP at $LDAP_HOST..."
+for i in $(seq 1 $MAX_RETRIES); do
+    if ldapsearch -x -H "$LDAP_HOST" -b "" -s base namingContexts >/dev/null 2>&1; then
+        echo "OpenLDAP is ready."
+        break
+    fi
+    if [ "$i" = "$MAX_RETRIES" ]; then
+        echo "OpenLDAP not ready after $MAX_RETRIES attempts, giving up."
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Applying ACLs..."
+ldapmodify -H "$LDAP_HOST" -D "cn=admin,cn=config" -w config <<'EOF'
+dn: olcDatabase={1}mdb,cn=config
+changetype: modify
+replace: olcAccess
+olcAccess: {0}to attrs=userPassword by self write by anonymous auth by * none
+olcAccess: {1}to * by users read by * none
+EOF
+
+echo "ACLs applied successfully."


### PR DESCRIPTION
## Description

Replaces the bring-your-own-LDAP dev setup with a hermetic stack. `docker compose --profile dev up -d` now boots everything needed to work on the app — no `.env.local` required, no real credentials involved.

Pattern borrowed from [netresearch/ldap-manager](https://github.com/netresearch/ldap-manager/blob/main/compose.yml) so we keep one dev-stack idiom across the org.

## Type of Change

- [x] 🔧 Configuration change
- [x] 📝 Documentation update (.env.local.example rewritten)

## Changes

- **OpenLDAP** (`osixia/openldap:1.5.0`) — seeded with `jdoe`, `jsmith`, and a `password-reset` service account via `dev/seed.ldif`. A one-shot `openldap-init` container applies an ACL so each user can change their own `userPassword` (mirrors Active Directory's default).
- **Mailpit** (`axllent/mailpit:latest`) — modern SMTP sink replacing MailHog (archived). Web UI on `:8025`.
- **App service** — ships all dev defaults inline in `compose.yml`; `.env.local` is now optional (`required: false`). Build context is the repo, so the real Dockerfile pipeline runs.
- **.env.local.example** rewritten as a commented, opt-in override template.

## Usage

```bash
docker compose --profile dev up -d --build
```

| URL | What |
|---|---|
| http://localhost:3000 | App |
| http://localhost:8025 | Mailpit inbox |

### Seeded users

| uid | password | email |
|---|---|---|
| `jdoe` | `password` | `john.doe@netresearch.local` |
| `jsmith` | `password` | `jane.smith@netresearch.local` |
| `password-reset` | `reset-password` | (service account) |

Admin bind: `cn=admin,dc=netresearch,dc=local` / `admin`

## Verified

- [x] `docker compose --profile dev up -d` → all 3 containers healthy
- [x] `curl -X POST /api/rpc -d '{"method":"request-password-reset",...}'` → HTTP 200, email lands in Mailpit
- [x] Page rendering + client-side UX (policy checklist, error summary, theme/density toggles) all exercised via Playwright during #537

## Known limitation

`simple-ldap-go`'s `ChangePasswordForSAMAccountName` / `ResetPasswordForSAMAccountName` hardcode AD's `unicodePwd` attribute. Against this OpenLDAP you'll see:

```
LDAP Result Code 17 "Undefined Attribute Type": unicodePwd: attribute type undefined
```

…when attempting an actual password write. Everything up to the write (form submission, LDAP search, email generation) works — so the UX (including the styled server-error path) is exercisable end-to-end. Follow-up work to add a generic-LDAP password write path to `simple-ldap-go` tracked separately.

## Deployment Notes

- [x] No database migrations required
- [x] No configuration changes required for existing deployments
- [x] No breaking API changes
- [x] Backward compatible

The `dev` profile is opt-in — production deployments continue to use `.env.local` without any docker changes.