### PR TITLE
chore(ci): migrate to canonical reusable workflows

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -4,33 +4,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    # Use .user.login (stable) instead of github.actor (changes on reruns)
-    if: >-
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
-    steps:
-      - name: Approve PR
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Enable auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          STRATEGY=$(gh api "repos/$REPO" --jq '
-            if .allow_squash_merge then "--squash"
-            elif .allow_merge_commit then "--merge"
-            elif .allow_rebase_merge then "--rebase"
-            else "--squash" end')
-          gh pr merge --auto "$STRATEGY" "$PR_URL"
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,47 +9,35 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  go-test:
-    name: Run Go tests
-    runs-on: ubuntu-latest
+  go:
+    name: Go
+    uses: netresearch/.github/.github/workflows/go-check.yml@main
+    with:
+      go-version-file: go.mod
+      setup-bun: true
+      pre-build-cmd: "bun install --frozen-lockfile && bun run build:assets"
+      enable-codecov: true
+      codecov-flags: "backend,unittests"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      security-events: write
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26"
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install && go mod download
-
-      - name: Check types
-        run: bun run build:assets
-
-      - name: Build
-        run: go build -v ./...
-
-      - name: Test with coverage
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.out
-          flags: backend,unittests
-          name: go-coverage
-          fail_ci_if_error: false
+  ts:
+    name: TypeScript
+    uses: netresearch/.github/.github/workflows/ts-check.yml@main
+    permissions:
+      contents: read
 
   integration-test:
     name: Run integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     services:
@@ -72,24 +60,32 @@ jobs:
           - 1025:1025
           - 8025:8025
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
-        run: bun install && go mod download
+        run: bun install --frozen-lockfile && go mod download
 
       - name: Build assets
         run: bun run build:assets
 
       - name: Run integration tests with coverage
-        run: go test -v -race -tags=integration -coverprofile=coverage-integration.out -covermode=atomic ./...
         env:
           LDAP_SERVER: ldap://localhost:1389
           LDAP_BASE_DN: dc=example,dc=com
@@ -97,6 +93,7 @@ jobs:
           LDAP_READONLY_PASSWORD: adminpassword
           SMTP_HOST: localhost
           SMTP_PORT: "1025"
+        run: go test -v -race -tags=integration -coverprofile=coverage-integration.out -covermode=atomic ./...
 
       - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -110,21 +107,31 @@ jobs:
   e2e-test:
     name: Run E2E tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
-        run: bun install && go mod download
+        run: bun install --frozen-lockfile && go mod download
 
       - name: Build assets
         run: bun run build:assets
@@ -144,98 +151,28 @@ jobs:
   fuzz-test:
     name: Fuzz tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
 
       - name: Run fuzz tests (quick)
         run: |
           go test -run=^$ -fuzz=FuzzValidateNewPassword -fuzztime=10s ./internal/rpchandler/...
           go test -run=^$ -fuzz=FuzzPluralize -fuzztime=10s ./internal/rpchandler/...
           go test -run=^$ -fuzz=FuzzValidateEmailAddress -fuzztime=10s ./internal/email/...
-
-  types:
-    name: Check types
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Check types
-        run: bun run js:build
-
-  formatting:
-    name: Check formatting
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Check formatting
-        run: bunx prettier --check .
-
-  lint-go:
-    name: Lint Go code
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26"
-          cache: true
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build assets
-        run: bun run build:assets
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-        with:
-          version: latest
-          args: --timeout=5m
-
-  lint-js:
-    name: Lint TypeScript/JavaScript
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run ESLint
-        run: bun run lint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   go:
     name: Go
-    uses: netresearch/.github/.github/workflows/go-check.yml@main
+    uses: netresearch/.github/.github/workflows/go-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     with:
       go-version-file: go.mod
       setup-bun: true
@@ -30,7 +30,7 @@ jobs:
 
   ts:
     name: TypeScript
-    uses: netresearch/.github/.github/workflows/ts-check.yml@main
+    uses: netresearch/.github/.github/workflows/ts-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL Security Analysis
+name: CodeQL
 
 on:
   push:
@@ -6,64 +6,17 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run weekly on Sundays at 00:00 UTC
+    # Weekly on Sundays at 00:00 UTC
     - cron: "0 0 * * 0"
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
-    name: Analyze Code
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: go
-            build-mode: autobuild
-          - language: javascript-typescript
-            build-mode: none
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Go
-        if: matrix.language == 'go'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26"
-          check-latest: true
-          cache: true
-
-      - name: Install Bun
-        if: matrix.language == 'javascript-typescript'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        if: matrix.language == 'javascript-typescript'
-        run: bun install
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-          queries: +security-and-quality
-          config: |
-            paths-ignore:
-              - '**/*.md'
-              - 'docs/**'
-              - 'claudedocs/**'
-              - '**/test/**'
-              - '**/*_test.go'
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        with:
-          category: "/language:${{ matrix.language }}"
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    with:
+      languages: go,javascript-typescript

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    uses: netresearch/.github/.github/workflows/codeql.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    uses: netresearch/.github/.github/workflows/build-container.yml@main
+    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -3,7 +3,9 @@
 # without manual review.
 #
 # SECURITY: uses pull_request_target which runs with base-branch perms.
-# The reusable does NOT checkout PR code into a privileged context.
+# We rely on the pinned reusable (see the `uses:` SHA below) to avoid
+# checking out PR code into a privileged context. Verify the pinned
+# commit before bumping the ref.
 #
 # Bootstrap: the PR that introduces this file must be approved manually
 # (the workflow isn't on the base branch yet). All subsequent PRs
@@ -19,7 +21,7 @@ permissions: {}
 
 jobs:
   quality:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,13 +1,13 @@
-# Solo-maintainer auto-approve: approves PRs from repo collaborators
-# so that required_approving_review_count >= 1 is satisfied without
-# manual review for trusted authors.
+# Solo-maintainer PR quality gates: size check + auto-approve for
+# collaborator PRs so required_approving_review_count >= 1 is satisfied
+# without manual review.
 #
-# SECURITY: This workflow uses pull_request_target which runs with base branch
-# permissions. NEVER add an actions/checkout step here -- that would allow code
-# from the PR to execute with write access to the repository.
+# SECURITY: uses pull_request_target which runs with base-branch perms.
+# The reusable does NOT checkout PR code into a privileged context.
 #
-# Bootstrap: The PR that introduces this workflow must be approved manually
-# (the workflow isn't on the base branch yet). All subsequent PRs auto-approve.
+# Bootstrap: the PR that introduces this file must be approved manually
+# (the workflow isn't on the base branch yet). All subsequent PRs
+# auto-approve.
 
 name: PR Quality Gates
 
@@ -15,32 +15,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
-  auto-approve:
-    name: Auto-approve (collaborators)
-    runs-on: ubuntu-latest
+  quality:
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
+      contents: read
       pull-requests: write
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
-      - name: Check author permission
-        id: check-permission
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          REPO: ${{ github.repository }}
-        run: |
-          PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
-          echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
-
-      - name: Auto-approve PR
-        if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   create-release:
     name: Create GitHub Release
-    uses: netresearch/.github/.github/workflows/create-release.yml@main
+    uses: netresearch/.github/.github/workflows/create-release.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: write
     with:
@@ -83,7 +83,7 @@ jobs:
   container:
     name: Build container image
     needs: create-release
-    uses: netresearch/.github/.github/workflows/build-container.yml@main
+    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Migrate four workflows to the canonical reusables that just landed in [`netresearch/.github@main`](https://github.com/netresearch/.github/tree/main/.github/workflows). Goal: every Go project in the org calls the SAME high-standard pipeline, no per-repo duplication.

## Files changed

| File | Before | After |
|------|--------|-------|
| `.github/workflows/auto-merge-deps.yml` | 27 lines inline `gh pr review` + strategy detection | 11-line call to `auto-merge-deps.yml@main` |
| `.github/workflows/codeql.yml` | 70-line inline CodeQL job with matrix | 22-line matrix caller of `codeql.yml@main` |
| `.github/workflows/pr-quality.yml` | 47-line collaborator check + harden-runner | 24-line call to `pr-quality.yml@main` |
| `.github/workflows/check.yml` | 242 lines, 8 inline jobs, ~16 direct action calls | 179 lines, 2 reusable calls + 3 retained inline jobs |

## Reusables called (with inputs)

- **`netresearch/.github/.github/workflows/go-check.yml@main`** — `go-version-file: go.mod`, `setup-bun: true`, `pre-build-cmd: "bun install --frozen-lockfile && bun run build:assets"`, `enable-codecov: true`, `codecov-flags: "backend,unittests"`. Secret passed: `CODECOV_TOKEN`.
- **`netresearch/.github/.github/workflows/ts-check.yml@main`** — all defaults (`bun install --frozen-lockfile`, `bun run js:build`, `bun run lint`, `bunx prettier --check .`).
- **`netresearch/.github/.github/workflows/codeql.yml@main`** — matrix over `go` and `javascript-typescript` (so `/language:` category stays correct per SARIF upload; the reusable takes a single language at a time).
- **`netresearch/.github/.github/workflows/pr-quality.yml@main`** — defaults.
- **`netresearch/.github/.github/workflows/auto-merge-deps.yml@main`** — defaults.

## What stays inline (and why)

Inside `check.yml`:

- **`integration-test`** — uses `services:` to spin up `osixia/openldap:1.5.0` + `mailhog/mailhog:v1.0.1` siblings with health checks and port mappings. GitHub's reusable `workflow_call` jobs can't cleanly express service containers for callers, so this stays as a caller-owned job.
- **`e2e-test`** — same story: depends on the build-asset chain and emits its own Codecov flag (`backend,e2e`). Will likely grow service deps too.
- **`fuzz-test`** — Go native fuzzing (`-fuzz=...`) isn't modeled in the current reusable. Low-ceremony inline job; will migrate when upstream adds it.

All three retained jobs now use:
- `go-version-file: go.mod` (no hardcoded `1.26`)
- `persist-credentials: false` on checkout
- `step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0`
- per-job `timeout-minutes`
— matching the reusables' hardening posture.

## Out of scope

Untouched: `release.yml` (complex GoReleaser + cosign + attest-build-provenance pipeline), `release-labeler.yml`, `docker.yml` (already calls `build-container.yml` reusable).

## Verification

- `actionlint .github/workflows/auto-merge-deps.yml .github/workflows/check.yml .github/workflows/codeql.yml .github/workflows/pr-quality.yml` — clean.
- `bun run js:build` — passes.
- `bun run build:assets && go test ./...` — all packages green.

## Expected CI outcome

**Same coverage**, different job names in the summary: reusable call labels look like `go / build-test`, `go / golangci-lint`, `go / govulncheck`, `go / gosec`, `ts / type-check`, `ts / lint`, `ts / format-check`, `analyze (go) / Analyze`, etc. instead of the previous `Run Go tests`, `Check types`, `Lint Go code`. The kept-inline `integration-test`, `e2e-test`, and `fuzz-test` jobs retain their names.

New jobs that didn't exist before (via `go-check`): `govulncheck`, `gosec` (SARIF upload). These widen security coverage.

## Test plan

- [ ] CI green on this PR (all reusable calls resolve, secrets forward correctly)
- [ ] Required-status-check names on branch protection still match (may need update to the new `go / build-test` etc. names after merge)
- [ ] CodeQL SARIF for both languages uploads to Security tab
- [ ] Codecov still receives `backend,unittests` flag from the reusable call