### PR TITLE
chore(ci): unpin netresearch/.github reusables back to @main

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   go:
     name: Go
-    uses: netresearch/.github/.github/workflows/go-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/go-check.yml@main
     with:
       go-version-file: go.mod
       setup-bun: true
@@ -30,7 +30,7 @@ jobs:
 
   ts:
     name: TypeScript
-    uses: netresearch/.github/.github/workflows/ts-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/ts-check.yml@main
     permissions:
       contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   quality:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -3,9 +3,11 @@
 # without manual review.
 #
 # SECURITY: uses pull_request_target which runs with base-branch perms.
-# We rely on the pinned reusable (see the `uses:` SHA below) to avoid
-# checking out PR code into a privileged context. Verify the pinned
-# commit before bumping the ref.
+# The `@main` reference points at the org's own reusables repo
+# (netresearch/.github), which shares this repo's trust boundary and is
+# gated by its own branch protection + CI. The reusable is expected not
+# to check out PR code into this privileged context; changes there are
+# reviewed in-repo before landing on main.
 #
 # Bootstrap: the PR that introduces this file must be approved manually
 # (the workflow isn't on the base branch yet). All subsequent PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   create-release:
     name: Create GitHub Release
-    uses: netresearch/.github/.github/workflows/create-release.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/create-release.yml@main
     permissions:
       contents: write
     with:
@@ -83,7 +83,7 @@ jobs:
   container:
     name: Build container image
     needs: create-release
-    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The earlier SHA-pin commit treated org-internal reusables like third-party actions. It shouldn't have.

**Pinning \`actions/checkout@<sha>\`**: correct. Upstream is outside our trust boundary; a maintainer-key compromise is a real threat; SHA = immutable guarantee.

**Pinning \`netresearch/.github/...@<sha>\`**: security theater in our setup.

- Same trust boundary — anyone who could force-push the reusables repo already owns the caller repos.
- Reintroduces the duplication the migration just eliminated: every reusable change needs a Renovate PR in every caller.
- Delays security fixes by the Renovate cycle instead of applying immediately.
- \`netresearch/.github:main\` has its own branch protection and CI gates — attacking it is the same bar as attacking any other main branch in the org.

This reverts the internal refs to \`@main\`. External-action SHA pins (\`actions/*\`, \`oven-sh/*\`, \`step-security/*\`, etc.) are **kept** — that's where pinning is actually meaningful.