### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,10 @@ updates:
     groups:
       docker:
         patterns: ['*']
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,10 +3,10 @@ documentation:
       - any-glob-to-any-file: ['**/*.md', 'docs/**/*']
 ci:
   - changed-files:
-      - any-glob-to-any-file: ['.github/**/*']
+      - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file: ['go.mod', 'go.sum']
+      - any-glob-to-any-file: ['go.mod', 'go.sum', 'Dockerfile', '.devcontainer/**/*']
 tests:
   - changed-files:
       - any-glob-to-any-file: ['**/*_test.go', 'testdata/**/*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
       enable-fuzz: true
       enable-license-check: true
       enable-codecov: true
-      coverage-threshold: 60
-      setup-bun: true
-      pre-build-cmd: "bun install --frozen-lockfile && bun run build:assets"
+      coverage-threshold: 80.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/container-retention.yml
+++ b/.github/workflows/container-retention.yml
@@ -17,7 +17,7 @@ jobs:
     uses: netresearch/.github/.github/workflows/ghcr-retention.yml@main
     with:
       package-name: ${{ github.event.repository.name }}
-      dry-run: ${{ inputs.dry-run != false }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
     permissions:
       packages: write
       attestations: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   create:
     uses: netresearch/.github/.github/workflows/create-release.yml@main
     with:
-      tag: ${{ inputs.tag || '' }}
+      tag: ${{ inputs.tag || github.ref_name }}
     permissions:
       contents: write
 


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.