### PR TITLE
fix(.gitignore): anchor /ldap-selfservice-password-changer to avoid shadowing source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ internal/web/static/styles.css
 # Claude Code temporary documentation
 claudedocs/
 vendor/
-ldap-selfservice-password-changer
+/ldap-selfservice-password-changer
 
 # Test coverage
 coverage.out


### PR DESCRIPTION
Fleet-wide .gitignore hardening. Bare `ldap-selfservice-password-changer` matches any file or directory of that name anywhere in the tree; anchor with `/` so only the repo-root binary is ignored. Pre-emptive fix for the same class of bug that hit ldap-manager's cmd/ldap-manager/main_test.go earlier.