### PR TITLE
fix(release): narrow platforms (Fiber 32-bit) + populate version vars

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -7,3 +7,7 @@ intentional-drift:
   reason: TypeScript frontend assets must be built via bun before go test; caller-level
     setup-bun + pre-build-cmd required (pre-build-cmd also drops a go.mod into node_modules
     so the vendored `flatted` npm package's Go source does not pollute `go test ./...`)
+- path: .github/workflows/release.yml
+  reason: "binaries matrix and container platforms narrowed to amd64+arm64 — gofiber/fiber/v3
+    uses math.MaxUint32 which overflows int on 32-bit targets (linux/386, linux/arm/v6,
+    linux/arm/v7). Revisit when Fiber upstream ships a 32-bit-safe release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,15 @@ jobs:
     needs: create-release
     strategy:
       fail-fast: false
+      # INTENTIONAL DRIFT from netresearch/.github go-app template:
+      # 32-bit linux targets (386, arm/v6, arm/v7) cannot compile this
+      # repo because gofiber/fiber/v3 uses math.MaxUint32 which overflows
+      # int on 32-bit platforms. Recorded in .github/template.yaml
+      # intentional-drift; revisit when upstream Fiber ships a 32-bit fix.
       matrix:
         include:
-          - { target: linux-386,     goos: linux,   goarch: "386" }
           - { target: linux-amd64,   goos: linux,   goarch: amd64 }
           - { target: linux-arm64,   goos: linux,   goarch: arm64 }
-          - { target: linux-armv6,   goos: linux,   goarch: arm,   goarm: "6" }
-          - { target: linux-armv7,   goos: linux,   goarch: arm,   goarm: "7" }
           - { target: darwin-amd64,  goos: darwin,  goarch: amd64 }
           - { target: darwin-arm64,  goos: darwin,  goarch: arm64 }
           - { target: windows-amd64, goos: windows, goarch: amd64 }
@@ -70,7 +72,8 @@ jobs:
       main-package: auto
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
-      goarm: ${{ matrix.goarm || '' }}
+      # goarm intentionally omitted — narrowed matrix has no arm/v* entries
+      # (see INTENTIONAL DRIFT comment above).
       ldflags: "-s -w -X main.version=${{ needs.create-release.outputs.tag }} -X main.build=${{ needs.create-release.outputs.sha }}"
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
@@ -101,13 +104,14 @@ jobs:
     with:
       image-name: ${{ github.event.repository.name }}
       ref: ${{ needs.create-release.outputs.tag }}
-      platforms: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+      # Narrowed to match the binaries matrix above (Fiber v3 32-bit).
+      platforms: "linux/amd64,linux/arm64"
       sign: true
       attest: true
       pre-build-command: |
         set -euo pipefail
         mkdir -p bin
-        for suffix in linux-386 linux-amd64 linux-arm64 linux-armv6 linux-armv7; do
+        for suffix in linux-amd64 linux-arm64; do
           gh release download "${{ needs.create-release.outputs.tag }}" \
             --pattern "${{ github.event.repository.name }}-${suffix}" --dir bin
           chmod +x "bin/${{ github.event.repository.name }}-${suffix}"

--- a/main.go
+++ b/main.go
@@ -269,6 +269,15 @@ func buildServer(opts *options.Opts) (*fiber.App, error) {
 	return app, nil
 }
 
+// Build-injected version metadata. Populated by the release.yml ldflags
+// (`-X main.version=<tag> -X main.build=<commit-sha>`); empty for local
+// `go run .` / `go build`. Log them on startup so operators can confirm
+// which artifact they're running.
+var (
+	version = "dev"
+	build   = ""
+)
+
 // healthCheckFunc is the indirection used by run() to invoke the health check.
 // Tests override this to assert that the --health-check branch is actually
 // taken and to control the outcome deterministically. Production code uses
@@ -304,7 +313,7 @@ func run(args []string) int {
 		return 1
 	}
 
-	slog.Info("starting server", "port", opts.Port)
+	slog.Info("starting server", "port", opts.Port, "version", version, "build", build)
 	if err := app.Listen(":" + opts.Port); err != nil {
 		slog.Error("failed to start web server", "error", err)
 		return 1


### PR DESCRIPTION
## Summary

Two follow-ups from [#565](https://github.com/netresearch/ldap-selfservice-password-changer/pull/565) (Copilot review).

### 1. Narrow platforms — Fiber v3 32-bit incompatibility

Binaries matrix and container platforms narrowed to `amd64` + `arm64` (5 desktop/server targets total). `gofiber/fiber/v3` uses `math.MaxUint32` which overflows int on 32-bit platforms (linux/386, linux/arm/v6, linux/arm/v7), so the full 5-platform go-app template matrix would fail at `go build` for those targets. This repo's pre-standardization `.goreleaser.yml` has the same ignore-list for the same reason.

Recorded in `.github/template.yaml` intentional-drift so the drift check stays green. Revisit when upstream Fiber ships a 32-bit-safe release.

### 2. Populate release-time version metadata

Add `var version, build string` to `main.go`. The template's release ldflags (`-X main.version=<tag> -X main.build=<commit>`) now land in real package-level variables that are logged at server startup. Before this, tagged releases would still show "dev" in runtime logs.

## Test plan

- [x] actionlint clean.
- [x] `go build ./...` succeeds (with frontend assets).
- [ ] Next tagged release: 5 release assets (amd64/arm64 variants), ghcr image for linux/amd64+linux/arm64, and `version=<tag>` in startup logs.