### PR TITLE
chore(release): align ldflags + buildTime receiver with fleet convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,15 @@ jobs:
       goarch: ${{ matrix.goarch }}
       # goarm intentionally omitted — narrowed matrix has no arm/v* entries
       # (see INTENTIONAL DRIFT comment above).
-      ldflags: "-s -w -X main.version=${{ needs.create-release.outputs.tag }} -X main.build=${{ needs.create-release.outputs.sha }}"
+      # Fleet ldflag convention (netresearch/.github#74) — main.buildTime
+      # is a silent no-op here (no BuildTimestamp consumer yet) but kept
+      # aligned so this release.yml only drifts from the template on the
+      # Fiber-32-bit-ignored matrix, nothing else.
+      ldflags: >-
+        -s -w
+        -X main.version=${{ needs.create-release.outputs.tag }}
+        -X main.build=${{ needs.create-release.outputs.sha }}
+        -X main.buildTime=${{ github.event.head_commit.timestamp }}
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true

--- a/main.go
+++ b/main.go
@@ -269,13 +269,21 @@ func buildServer(opts *options.Opts) (*fiber.App, error) {
 	return app, nil
 }
 
-// Build-injected version metadata. Populated by the release.yml ldflags
-// (`-X main.version=<tag> -X main.build=<commit-sha>`); empty for local
-// `go run .` / `go build`. Log them on startup so operators can confirm
-// which artifact they're running.
+// Build-injected version metadata. Populated by release.yml's ldflags:
+//
+//	-X main.version=<tag>
+//	-X main.build=<commit-sha>
+//	-X main.buildTime=<commit-timestamp>
+//
+// `version` defaults to "dev" so local `go run .` / `go build` logs
+// something meaningful; `build` and `buildTime` default to empty and
+// are kept as declared receivers so the fleet-uniform ldflag string
+// always has a target (no risk of unknown-symbol linker strictness).
+// Logged on startup so operators can confirm which artifact is live.
 var (
-	version = "dev"
-	build   = ""
+	version   = "dev"
+	build     = ""
+	buildTime = ""
 )
 
 // healthCheckFunc is the indirection used by run() to invoke the health check.
@@ -313,7 +321,7 @@ func run(args []string) int {
 		return 1
 	}
 
-	slog.Info("starting server", "port", opts.Port, "version", version, "build", build)
+	slog.Info("starting server", "port", opts.Port, "version", version, "build", build, "buildTime", buildTime)
 	if err := app.Listen(":" + opts.Port); err != nil {
 		slog.Error("failed to start web server", "error", err)
 		return 1


### PR DESCRIPTION
## Summary

ldap-ssp's `release.yml` was left behind on the old 2-flag ldflags because the whole file is on the intentional-drift list (Fiber v3 32-bit matrix narrow). That drift entry covers the matrix narrowing only; staying on the old ldflags was collateral, not intentional.

- **`release.yml`**: bring ldflags inline with the [netresearch/.github#74](https://github.com/netresearch/.github/pull/74) template — three `-X` targets (`main.version`, `main.build`, `main.buildTime`). Narrowed matrix + intentional-drift comment stay. Only real difference from template now: `linux/amd64,linux/arm64` platforms.
- **`main.go`**: declare `var buildTime string` as a receiver, include in the structured startup log next to `version` + `build`. Empty here (no BuildTimestamp consumer yet) — cheap insurance vs. any future linker strictness.