### PR TITLE
chore(main,release): snake_case log key + updated buildTime comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,12 @@ jobs:
       goarch: ${{ matrix.goarch }}
       # goarm intentionally omitted — narrowed matrix has no arm/v* entries
       # (see INTENTIONAL DRIFT comment above).
-      # Fleet ldflag convention (netresearch/.github#74) — main.buildTime
-      # is a silent no-op here (no BuildTimestamp consumer yet) but kept
-      # aligned so this release.yml only drifts from the template on the
-      # Fiber-32-bit-ignored matrix, nothing else.
+      # Fleet ldflag convention (netresearch/.github#74). main.buildTime
+      # is surfaced only via the `build_time` attribute in main.go's
+      # server-startup slog call — no dedicated timestamp subcommand is
+      # wired. Keeping the ldflag aligned with the template means this
+      # release.yml only drifts on the Fiber-32-bit-ignored matrix,
+      # nothing else.
       ldflags: >-
         -s -w
         -X main.version=${{ needs.create-release.outputs.tag }}

--- a/main.go
+++ b/main.go
@@ -321,7 +321,7 @@ func run(args []string) int {
 		return 1
 	}
 
-	slog.Info("starting server", "port", opts.Port, "version", version, "build", build, "buildTime", buildTime)
+	slog.Info("starting server", "port", opts.Port, "version", version, "build", build, "build_time", buildTime)
 	if err := app.Listen(":" + opts.Port); err != nil {
 		slog.Error("failed to start web server", "error", err)
 		return 1


### PR DESCRIPTION
Copilot review on [#568](https://github.com/netresearch/ldap-selfservice-password-changer/pull/568):

- **main.go**: rename slog attribute key from `buildTime` (camelCase) to `build_time` to match the snake_case convention of the other attributes in this repo.
- **release.yml**: the inline comment said `main.buildTime is a silent no-op (no BuildTimestamp consumer yet)`, but main.go now logs it on startup. Reword to describe the actual consumer (`build_time` slog attribute) so a future reader doesn't delete the ldflag thinking it's dead code.