### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     groups:
       go-dependencies:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -19,6 +21,8 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
@@ -29,6 +33,8 @@ updates:
     groups:
       docker:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /
@@ -39,6 +45,8 @@ updates:
     groups:
       npm:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: devcontainers
     directory: /
@@ -49,3 +57,5 @@ updates:
     groups:
       devcontainers:
         patterns: ['*']
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.