### PR TITLE
ci(dependabot): self-manage config, opt-in bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,10 @@
+# Self-managed — intentional-drift from netresearch/.github templates/go-app.
+# Core ecosystems (gomod, github-actions, docker) track the go-app template;
+# the npm block is kept here because this repo has a package.json (bun/TypeScript
+# frontend) the trimmed template no longer declares (see netresearch/.github#166).
+# This file is listed under intentional-drift in .github/template.yaml so the
+# template sync leaves it alone — keep the core blocks in step with the template
+# manually.
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -44,18 +51,6 @@ updates:
     open-pull-requests-limit: 5
     groups:
       npm:
-        patterns: ['*']
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 2
-    groups:
-      devcontainers:
         patterns: ['*']
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 # Self-managed — intentional-drift from netresearch/.github templates/go-app.
 # Core ecosystems (gomod, github-actions, docker) track the go-app template;
-# the npm block is kept here because this repo has a package.json (bun/TypeScript
-# frontend) the trimmed template no longer declares (see netresearch/.github#166).
+# the bun block is kept here because this repo has a package.json + text-based
+# bun.lock (Bun/TypeScript frontend) the trimmed template no longer declares
+# (see netresearch/.github#166). Dependabot has a dedicated `bun` ecosystem that
+# reads package.json + bun.lock, so it is used here instead of `npm`.
 # This file is listed under intentional-drift in .github/template.yaml so the
 # template sync leaves it alone — keep the core blocks in step with the template
 # manually.
@@ -43,14 +45,14 @@ updates:
     cooldown:
       default-days: 7
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
     groups:
-      npm:
+      bun:
         patterns: ['*']
     cooldown:
       default-days: 7

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -12,4 +12,4 @@ intentional-drift:
     uses math.MaxUint32 which overflows int on 32-bit targets (linux/386, linux/arm/v6,
     linux/arm/v7). Revisit when Fiber upstream ships a 32-bit-safe release."
 - path: .github/dependabot.yml
-  reason: "Opt-in npm ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a package.json (bun/TypeScript frontend) so it self-manages dependabot.yml to keep npm updates. Core blocks are kept in step with the template manually."
+  reason: "Opt-in bun ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a package.json + bun.lock (Bun/TypeScript frontend) so it self-manages dependabot.yml to keep bun updates via Dependabot's dedicated bun ecosystem. Core blocks are kept in step with the template manually."

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -11,3 +11,5 @@ intentional-drift:
   reason: "binaries matrix and container platforms narrowed to amd64+arm64 — gofiber/fiber/v3
     uses math.MaxUint32 which overflows int on 32-bit targets (linux/386, linux/arm/v6,
     linux/arm/v7). Revisit when Fiber upstream ships a 32-bit-safe release."
+- path: .github/dependabot.yml
+  reason: "Opt-in npm ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a package.json (bun/TypeScript frontend) so it self-manages dependabot.yml to keep npm updates. Core blocks are kept in step with the template manually."


### PR DESCRIPTION
Follow-up to netresearch/.github#166, which trimmed the `go-app` template's dependabot.yml to the universally-present ecosystems (gomod, github-actions, docker). This repo has a package.json (bun/TypeScript frontend), so it keeps the `npm` ecosystem by self-managing `.github/dependabot.yml` and listing it under `intentional-drift:` in `.github/template.yaml`.

Also drops the ecosystem this repo has no manifest for (was failing Dependabot with `dependency_file_not_found`). Core blocks (gomod/github-actions/docker) stay in step with the template manually.

## Test plan
- [ ] After merge: `event=dynamic` Dependabot runs go green (no `dependency_file_not_found`).