### PR TITLE
chore: sync go-app template drift

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,6 +1,11 @@
 name: Auto-merge dependency PRs
 
-on:
+# pull_request_target is required: approving/enabling auto-merge on fork
+# dependency PRs needs a write-scoped token, which pull_request does not
+# provide. The called reusable workflow only runs gh-CLI review/merge steps
+# gated on dependabot/renovate authorship (no checkout or execution of
+# untrusted PR code), so the usual pull_request_target risk does not apply.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
 
 permissions: {}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,10 @@
 name: Labeler
 
-on:
+# pull_request_target is required: labeling fork PRs needs a write-scoped
+# token, which pull_request does not provide. The called reusable workflow
+# only runs actions/labeler (no checkout or execution of untrusted PR code),
+# so the usual pull_request_target risk does not apply here.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Syncs `labeler.yml` + `auto-merge-deps.yml` (workflows) and the `.github/labeler.yml` config to the current `go-app` template, resolving the Template-drift check. The workflow changes are the zizmor `dangerous-triggers` ignore comments from netresearch/.github#237; the config change adds JS/TS glob patterns (inert for a Go repo). No behavior change.