### PR TITLE
feat(reset): accept username or email for password reset (RESET_IDENTIFIER_MODE)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,6 +26,12 @@
 
 # --- Reset feature -----------------------------------------------------
 # PASSWORD_RESET_ENABLED=true
+# Which identifier the reset form accepts: email (default), username, or both.
+# Use `username` or `both` when several accounts share one email address
+# (Active Directory does not enforce a unique mail attribute). The reset link
+# is always sent to the account's registered email address, never to the typed
+# value.
+# RESET_IDENTIFIER_MODE=email
 # RESET_TOKEN_EXPIRY_MINUTES=15
 # RESET_RATE_LIMIT_REQUESTS=3
 # RESET_RATE_LIMIT_WINDOW_MINUTES=60

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ GopherPass is configured via environment variables or command-line flags. Key se
 - `SMTP_USERNAME` / `SMTP_PASSWORD` - SMTP authentication
 - `SMTP_FROM_ADDRESS` - Sender email address
 - `APP_BASE_URL` - Base URL for reset links
+- `RESET_IDENTIFIER_MODE` - Identifier the reset form accepts: `email`, `username`, or `both` (default: `email`)
 - `RESET_TOKEN_EXPIRY_MINUTES` - Token validity (default: 15)
 - `RESET_RATE_LIMIT_REQUESTS` - Max requests per window (default: 3)
 
@@ -123,11 +124,11 @@ The password reset feature allows users to reset forgotten passwords via secure 
 - **Token Expiration**: Tokens expire after 15 minutes (configurable)
 - **Single-Use Tokens**: Tokens cannot be reused after password reset
 - **No User Enumeration**: Generic responses prevent account discovery
-- **Directory Integration**: Automatic email-to-username lookup
+- **Directory Integration**: Automatic identifier-to-account lookup (email and/or username, see `RESET_IDENTIFIER_MODE`)
 
 ### How It Works
 
-1. User navigates to `/forgot-password` and enters their email
+1. User navigates to `/forgot-password` and enters their email address or username (per `RESET_IDENTIFIER_MODE`; the reset link always goes to the account's registered email address)
 2. System looks up user in directory and generates secure token
 3. Reset email sent with link: `https://your-domain.com/reset-password?token=XXX`
 4. User clicks link, enters new password with real-time validation

--- a/cmd/uitest/main.go
+++ b/cmd/uitest/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("render index: %v", err)
 	}
-	forgot, err := templates.RenderForgotPassword()
+	forgot, err := templates.RenderForgotPassword(opts)
 	if err != nil {
 		log.Fatalf("render forgot: %v", err)
 	}

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -260,7 +260,7 @@ Response: {
 ```typescript
 Request: {
   method: "request-password-reset",
-  params: [email]
+  params: [emailOrUsername]
 }
 Response: {
   success: true
@@ -270,10 +270,17 @@ Response: {
 **Handler**: `internal/rpchandler/request_password_reset.go`
 
 - Rate limiting check (3 requests/hour per IP)
-- Lookup user by email in LDAP
+- Resolve the account per `RESET_IDENTIFIER_MODE` (`email` default, `username`, or `both`).
+  In `both`, an input containing `@` is looked up by email, otherwise by username.
 - Generate secure reset token
-- Send reset email with token link
-- Always returns success (prevents email enumeration)
+- Send reset email with token link — always to the account's LDAP-registered
+  address, never to the typed identifier
+- Always returns success (prevents account enumeration)
+
+**`RESET_IDENTIFIER_MODE`**: `username` / `both` exist because Active Directory does
+not enforce a unique `mail` attribute; an email shared by multiple accounts is
+ambiguous and yields the generic success without sending mail (those users reset via
+their unique username).
 
 #### `reset-password`
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,6 +165,12 @@ PASSWORD_CAN_INCLUDE_USERNAME=false
 # Enable password reset functionality (default: true)
 PASSWORD_RESET_ENABLED=true
 
+# Identifier accepted by the reset form: email, username, or both (default: email)
+# Use username/both when several accounts share one email address (AD does not
+# enforce a unique mail attribute). The reset link always goes to the account's
+# registered email address.
+RESET_IDENTIFIER_MODE=email
+
 # Token expiry in minutes (default: 15)
 RESET_TOKEN_EXPIRY_MINUTES=15
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -95,15 +95,15 @@ Time to guess: 2^256 / 1000 ≈ 10^73 years
 
 ---
 
-#### 3. Email Enumeration
+#### 3. Account Enumeration
 
-**Attack**: Attacker discovers valid email addresses by testing reset requests.
+**Attack**: Attacker discovers valid email addresses or usernames by testing reset requests (the form accepts email and/or username per `RESET_IDENTIFIER_MODE`).
 
 **Mitigations**:
 
-- Always return success response regardless of email validity
+- Always return success response regardless of identifier validity
 - Rate limiting prevents mass enumeration (3 requests/hour per IP)
-- No timing differences between valid/invalid emails
+- No timing differences between valid/invalid identifiers
 
 **Residual Risk**: Medium - rate limiting can be circumvented with distributed IPs
 
@@ -252,11 +252,11 @@ Result: Library escapes parentheses, preventing injection
 
 **Password Reset Flow**:
 
-1. User provides email address
-2. Application rate-limits request (3/hour per IP)
-3. Lookup user by email in LDAP (read-only account)
+1. User provides email address or username (per `RESET_IDENTIFIER_MODE`, default email-only)
+2. Application rate-limits request (per IP, per typed identifier, and per resolved account)
+3. Lookup user by email or username in LDAP (read-only account)
 4. Generate 256-bit cryptographic token
-5. Store token in memory with email and expiration
+5. Store token in memory with the account's registered email and expiration
 6. Send token link via email (out-of-band)
 7. User clicks link, submits token + new password
 8. Application validates token, retrieves email

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -42,7 +42,7 @@ func createTestApp(t *testing.T) *fiber.App {
 	indexPage, err := templates.RenderIndex(opts)
 	require.NoError(t, err)
 
-	forgotPasswordPage, err := templates.RenderForgotPassword()
+	forgotPasswordPage, err := templates.RenderForgotPassword(opts)
 	require.NoError(t, err)
 
 	resetPasswordPage, err := templates.RenderResetPassword(opts)

--- a/internal/options/app.go
+++ b/internal/options/app.go
@@ -13,6 +13,28 @@ import (
 	ldap "github.com/netresearch/simple-ldap-go"
 )
 
+// ResetIdentifierMode selects which identifier types the password reset form accepts.
+type ResetIdentifierMode string
+
+const (
+	// ResetIdentifierEmail accepts only email addresses (default, backward compatible).
+	ResetIdentifierEmail ResetIdentifierMode = "email"
+	// ResetIdentifierUsername accepts only usernames (sAMAccountName / uid).
+	ResetIdentifierUsername ResetIdentifierMode = "username"
+	// ResetIdentifierBoth accepts either an email address or a username in one field.
+	ResetIdentifierBoth ResetIdentifierMode = "both"
+)
+
+// Valid reports whether the mode is a recognized value.
+func (m ResetIdentifierMode) Valid() bool {
+	switch m {
+	case ResetIdentifierEmail, ResetIdentifierUsername, ResetIdentifierBoth:
+		return true
+	default:
+		return false
+	}
+}
+
 // Opts holds application configuration from environment variables and command-line flags.
 type Opts struct {
 	Port             string
@@ -29,6 +51,7 @@ type Opts struct {
 
 	// Password Reset Configuration
 	PasswordResetEnabled        bool
+	ResetIdentifierMode         ResetIdentifierMode
 	ResetTokenExpiryMinutes     uint
 	ResetRateLimitRequests      uint
 	ResetRateLimitWindowMinutes uint
@@ -191,6 +214,11 @@ func ParseArgs(args []string) (*Opts, error) {
 			envBoolOrDefault("PASSWORD_RESET_ENABLED", false, errs),
 			"Enable password reset feature.",
 		)
+		fResetIdentifierMode = fs.String(
+			"reset-identifier-mode",
+			envStringOrDefault("RESET_IDENTIFIER_MODE", string(ResetIdentifierEmail)),
+			"Which identifier the password reset form accepts: `email`, `username`, or `both`.",
+		)
 		fResetTokenExpiryMinutes = fs.Uint(
 			"reset-token-expiry-minutes",
 			envIntOrDefault("RESET_TOKEN_EXPIRY_MINUTES", 15, errs),
@@ -252,6 +280,15 @@ func ParseArgs(args []string) (*Opts, error) {
 		errs.Add(fmt.Sprintf("flag parsing error: %v", err))
 	}
 
+	// Normalize and validate the password reset identifier mode
+	resetIdentifierMode := ResetIdentifierMode(strings.ToLower(strings.TrimSpace(*fResetIdentifierMode)))
+	if !resetIdentifierMode.Valid() {
+		errs.Add(fmt.Sprintf(
+			"invalid value for reset-identifier-mode: %q (expected email, username, or both)",
+			*fResetIdentifierMode,
+		))
+	}
+
 	// Collect all missing required options
 	var missing []string
 	checkRequired("ldap-server", fLdapServer, &missing)
@@ -287,6 +324,7 @@ func ParseArgs(args []string) (*Opts, error) {
 		PasswordCanIncludeUsername: *fPasswordCanIncludeUsername,
 
 		PasswordResetEnabled:        *fPasswordResetEnabled,
+		ResetIdentifierMode:         resetIdentifierMode,
 		ResetTokenExpiryMinutes:     *fResetTokenExpiryMinutes,
 		ResetRateLimitRequests:      *fResetRateLimitRequests,
 		ResetRateLimitWindowMinutes: *fResetRateLimitWindowMinutes,

--- a/internal/options/app_test.go
+++ b/internal/options/app_test.go
@@ -614,3 +614,74 @@ func TestParseArgsUnknownFlag(t *testing.T) {
 	require.True(t, ok, "error should be *ConfigError")
 	assert.Contains(t, configErr.Error(), "flag parsing error")
 }
+
+// TestResetIdentifierModeValid tests the Valid method including unknown values.
+func TestResetIdentifierModeValid(t *testing.T) {
+	tests := []struct {
+		name string
+		mode ResetIdentifierMode
+		want bool
+	}{
+		{"email", ResetIdentifierEmail, true},
+		{"username", ResetIdentifierUsername, true},
+		{"both", ResetIdentifierBoth, true},
+		{"empty", ResetIdentifierMode(""), false},
+		{"unknown", ResetIdentifierMode("bogus"), false},
+		{"uppercase not normalized here", ResetIdentifierMode("EMAIL"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.mode.Valid())
+		})
+	}
+}
+
+// TestParseArgsResetIdentifierMode tests parsing, normalization, defaulting,
+// and rejection of the reset identifier mode.
+func TestParseArgsResetIdentifierMode(t *testing.T) {
+	setRequired := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("LDAP_SERVER", "ldap://example.com")
+		t.Setenv("LDAP_BASE_DN", "dc=example,dc=com")
+		t.Setenv("LDAP_READONLY_USER", "cn=readonly")
+		t.Setenv("LDAP_READONLY_PASSWORD", "secret")
+		t.Chdir(t.TempDir())
+	}
+
+	valid := []struct {
+		name  string
+		value string // empty string = unset (envStringOrDefault falls back)
+		want  ResetIdentifierMode
+	}{
+		{"default is email", "", ResetIdentifierEmail},
+		{"email", "email", ResetIdentifierEmail},
+		{"username", "username", ResetIdentifierUsername},
+		{"both", "both", ResetIdentifierBoth},
+		{"uppercase normalized", "BOTH", ResetIdentifierBoth},
+		{"whitespace trimmed", "  username  ", ResetIdentifierUsername},
+	}
+
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			setRequired(t)
+			t.Setenv("RESET_IDENTIFIER_MODE", tt.value)
+
+			opts, err := ParseArgs(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, opts.ResetIdentifierMode)
+		})
+	}
+
+	t.Run("invalid value rejected", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("RESET_IDENTIFIER_MODE", "bogus")
+
+		_, err := ParseArgs(nil)
+		require.Error(t, err)
+
+		configErr, ok := errors.AsType[*ConfigError](err)
+		require.True(t, ok, "error should be *ConfigError")
+		assert.Contains(t, configErr.Error(), "invalid value for reset-identifier-mode")
+	})
+}

--- a/internal/rpchandler/change_password_internal_test.go
+++ b/internal/rpchandler/change_password_internal_test.go
@@ -279,6 +279,10 @@ func (m *mockChangePasswordLDAP) FindUserByMail(_ string) (*ldap.User, error) {
 	return &ldap.User{SAMAccountName: "testuser"}, nil
 }
 
+func (m *mockChangePasswordLDAP) FindUserBySAMAccountName(_ string) (*ldap.User, error) {
+	return &ldap.User{SAMAccountName: "testuser"}, nil
+}
+
 func (m *mockChangePasswordLDAP) ChangePasswordForSAMAccountName(_, _, _ string) error {
 	return m.changePasswordError
 }

--- a/internal/rpchandler/handler.go
+++ b/internal/rpchandler/handler.go
@@ -16,6 +16,7 @@ type Func = func(params []string) ([]string, error)
 // LDAPClient interface for LDAP operations (enables testing).
 type LDAPClient interface {
 	FindUserByMail(mail string) (*ldap.User, error)
+	FindUserBySAMAccountName(sAMAccountName string) (*ldap.User, error)
 	ChangePasswordForSAMAccountName(sAMAccountName, oldPassword, newPassword string) error
 	ResetPasswordForSAMAccountName(sAMAccountName, newPassword string) error
 }

--- a/internal/rpchandler/handler_internal_test.go
+++ b/internal/rpchandler/handler_internal_test.go
@@ -365,9 +365,8 @@ func (m *mockHandlerLDAP) FindUserByMail(_ string) (*ldap.User, error) {
 	return &ldap.User{SAMAccountName: "testuser", Mail: &email}, nil
 }
 
-func (m *mockHandlerLDAP) FindUserBySAMAccountName(_ string) (*ldap.User, error) {
-	email := "user@example.com"
-	return &ldap.User{SAMAccountName: "testuser", Mail: &email}, nil
+func (m *mockHandlerLDAP) FindUserBySAMAccountName(sAMAccountName string) (*ldap.User, error) {
+	return m.FindUserByMail(sAMAccountName)
 }
 
 func (m *mockHandlerLDAP) ChangePasswordForSAMAccountName(_, _, _ string) error {

--- a/internal/rpchandler/handler_internal_test.go
+++ b/internal/rpchandler/handler_internal_test.go
@@ -365,6 +365,11 @@ func (m *mockHandlerLDAP) FindUserByMail(_ string) (*ldap.User, error) {
 	return &ldap.User{SAMAccountName: "testuser", Mail: &email}, nil
 }
 
+func (m *mockHandlerLDAP) FindUserBySAMAccountName(_ string) (*ldap.User, error) {
+	email := "user@example.com"
+	return &ldap.User{SAMAccountName: "testuser", Mail: &email}, nil
+}
+
 func (m *mockHandlerLDAP) ChangePasswordForSAMAccountName(_, _, _ string) error {
 	if m.changePasswordError != "" {
 		return ldap.NewLDAPError("ChangePassword", "ldap://localhost", errors.New(m.changePasswordError))

--- a/internal/rpchandler/identifier_mode_internal_test.go
+++ b/internal/rpchandler/identifier_mode_internal_test.go
@@ -1,0 +1,179 @@
+package rpchandler
+
+import (
+	"testing"
+	"time"
+
+	ldap "github.com/netresearch/simple-ldap-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/options"
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/ratelimit"
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/resettoken"
+)
+
+// newResetHandler builds a handler wired with the given mock LDAP client and
+// identifier mode for the reset-request tests.
+func newResetHandler(
+	mode options.ResetIdentifierMode,
+	mockLDAP LDAPClient,
+	mockEmail *mockEmailService,
+	tokenStore TokenStore,
+) *Handler {
+	return &Handler{
+		ldap:         mockLDAP,
+		tokenStore:   tokenStore,
+		emailService: mockEmail,
+		rateLimiter:  ratelimit.NewLimiter(10, 60*time.Minute),
+		opts: &options.Opts{
+			ResetIdentifierMode:     mode,
+			ResetTokenExpiryMinutes: 15,
+		},
+	}
+}
+
+func strptr(s string) *string { return &s }
+
+// TestRequestPasswordResetUsernameModeSendsToRegisteredMail is the security-
+// critical regression: when looked up by username, the reset link must go to
+// the account's LDAP-registered address, never to the typed identifier.
+func TestRequestPasswordResetUsernameModeSendsToRegisteredMail(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		usersBySAM: map[string]*ldap.User{
+			"jdoe": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+		},
+	}
+	handler := newResetHandler(options.ResetIdentifierUsername, mockLDAP, mockEmail, tokenStore)
+
+	result, err := handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Equal(t, []string{msgResetEmailSent}, result)
+
+	require.Equal(t, "john.doe@example.com", mockEmail.lastTo,
+		"reset link must be sent to the LDAP-registered address, not the typed username")
+	require.NotEqual(t, "jdoe", mockEmail.lastTo, "must never send to the typed identifier")
+
+	token, err := tokenStore.Get(mockEmail.lastToken)
+	require.NoError(t, err)
+	require.Equal(t, "jdoe", token.Username)
+	require.Equal(t, "john.doe@example.com", token.Email)
+}
+
+// TestRequestPasswordResetUsernameModeNoMail: a resolved account without a
+// registered mail cannot receive a link — generic success, nothing sent.
+func TestRequestPasswordResetUsernameModeNoMail(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		usersBySAM: map[string]*ldap.User{
+			"jdoe": {SAMAccountName: "jdoe"}, // Mail is nil
+		},
+	}
+	handler := newResetHandler(options.ResetIdentifierUsername, mockLDAP, mockEmail, tokenStore)
+
+	result, err := handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Equal(t, []string{msgResetEmailSent}, result)
+	require.Empty(t, mockEmail.lastTo, "no mail address means no email is sent")
+	require.Zero(t, tokenStore.Count(), "no token is stored when no link can be sent")
+}
+
+// TestRequestPasswordResetBothModeRouting: the combined field routes by the
+// presence of "@" and sends to the correct address in each case.
+func TestRequestPasswordResetBothModeRouting(t *testing.T) {
+	t.Run("email input", func(t *testing.T) {
+		tokenStore := resettoken.NewStore()
+		mockEmail := &mockEmailService{}
+		mockLDAP := &mockLDAPClient{
+			users: map[string]*ldap.User{
+				"john.doe@example.com": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+			},
+		}
+		handler := newResetHandler(options.ResetIdentifierBoth, mockLDAP, mockEmail, tokenStore)
+
+		_, err := handler.requestPasswordReset([]string{"john.doe@example.com"})
+		require.NoError(t, err)
+		require.Equal(t, "john.doe@example.com", mockEmail.lastTo)
+	})
+
+	t.Run("username input", func(t *testing.T) {
+		tokenStore := resettoken.NewStore()
+		mockEmail := &mockEmailService{}
+		mockLDAP := &mockLDAPClient{
+			usersBySAM: map[string]*ldap.User{
+				"jdoe": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+			},
+		}
+		handler := newResetHandler(options.ResetIdentifierBoth, mockLDAP, mockEmail, tokenStore)
+
+		_, err := handler.requestPasswordReset([]string{"jdoe"})
+		require.NoError(t, err)
+		require.Equal(t, "john.doe@example.com", mockEmail.lastTo)
+	})
+}
+
+// TestRequestPasswordResetEmailModeRejectsUsername: in email-only mode a bare
+// username (no "@") is rejected without any LDAP lookup — generic success.
+func TestRequestPasswordResetEmailModeRejectsUsername(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		usersBySAM: map[string]*ldap.User{
+			"jdoe": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+		},
+	}
+	handler := newResetHandler(options.ResetIdentifierEmail, mockLDAP, mockEmail, tokenStore)
+
+	result, err := handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Equal(t, []string{msgResetEmailSent}, result)
+	require.Empty(t, mockEmail.lastTo, "username must not resolve in email-only mode")
+	require.Zero(t, tokenStore.Count())
+}
+
+// TestRequestPasswordResetDuplicatedMail: a non-unique email stays a generic
+// success with nothing sent (those users use the username path).
+func TestRequestPasswordResetDuplicatedMail(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		findUserByMailError: ldap.ErrMailDuplicated,
+	}
+	handler := newResetHandler(options.ResetIdentifierBoth, mockLDAP, mockEmail, tokenStore)
+
+	result, err := handler.requestPasswordReset([]string{"shared@example.com"})
+	require.NoError(t, err)
+	require.Equal(t, []string{msgResetEmailSent}, result)
+	require.Empty(t, mockEmail.lastTo)
+	require.Zero(t, tokenStore.Count())
+}
+
+// TestRequestPasswordResetEmptyModeDefaultsToEmail: an unset mode behaves like
+// email-only (backward compatible).
+func TestRequestPasswordResetEmptyModeDefaultsToEmail(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		users: map[string]*ldap.User{
+			"john.doe@example.com": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+		},
+		usersBySAM: map[string]*ldap.User{
+			"jdoe": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+		},
+	}
+	// Zero-value mode ("") must default to email.
+	handler := newResetHandler("", mockLDAP, mockEmail, tokenStore)
+
+	// Email resolves.
+	_, err := handler.requestPasswordReset([]string{"john.doe@example.com"})
+	require.NoError(t, err)
+	require.Equal(t, "john.doe@example.com", mockEmail.lastTo)
+
+	// Username does not.
+	mockEmail.lastTo = ""
+	_, err = handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Empty(t, mockEmail.lastTo)
+}

--- a/internal/rpchandler/identifier_mode_internal_test.go
+++ b/internal/rpchandler/identifier_mode_internal_test.go
@@ -226,6 +226,34 @@ func TestRequestPasswordResetAccountBucketNotPoisonableViaTypedInput(t *testing.
 	require.Equal(t, 1, tokenStore.Count())
 }
 
+// nilUserLDAPClient returns (nil, nil) from lookups — a contract violation a
+// third-party LDAPClient implementation could commit.
+type nilUserLDAPClient struct{ mockLDAPClient }
+
+func (m *nilUserLDAPClient) FindUserByMail(_ string) (*ldap.User, error) {
+	return nil, nil //nolint:nilnil // the contract violation under test
+}
+
+func (m *nilUserLDAPClient) FindUserBySAMAccountName(_ string) (*ldap.User, error) {
+	return nil, nil //nolint:nilnil // the contract violation under test
+}
+
+// TestRequestPasswordResetNilUserNoPanic: an LDAP client returning (nil, nil)
+// must yield the generic success, not a nil-dereference panic.
+func TestRequestPasswordResetNilUserNoPanic(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	handler := newResetHandler(options.ResetIdentifierBoth, &nilUserLDAPClient{}, mockEmail, tokenStore)
+
+	for _, identifier := range []string{"john.doe@example.com", "jdoe"} {
+		result, err := handler.requestPasswordReset([]string{identifier})
+		require.NoError(t, err)
+		require.Equal(t, []string{msgResetEmailSent}, result)
+	}
+	require.Empty(t, mockEmail.lastTo)
+	require.Zero(t, tokenStore.Count())
+}
+
 // TestRequestPasswordResetEmptyModeDefaultsToEmail: an unset mode behaves like
 // email-only (backward compatible).
 func TestRequestPasswordResetEmptyModeDefaultsToEmail(t *testing.T) {

--- a/internal/rpchandler/identifier_mode_internal_test.go
+++ b/internal/rpchandler/identifier_mode_internal_test.go
@@ -188,6 +188,44 @@ func TestRequestPasswordResetAccountRateLimitAcrossIdentifiers(t *testing.T) {
 	require.Equal(t, 3, tokenStore.Count(), "no additional token past the account budget")
 }
 
+// TestRequestPasswordResetAccountBucketNotPoisonableViaTypedInput: typing the
+// literal string "account:<username>" must NOT consume the victim's per-account
+// budget — the typed and account bucket namespaces are disjoint.
+func TestRequestPasswordResetAccountBucketNotPoisonableViaTypedInput(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	mockLDAP := &mockLDAPClient{
+		usersBySAM: map[string]*ldap.User{
+			"jdoe": {SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")},
+		},
+	}
+	handler := &Handler{
+		ldap:         mockLDAP,
+		tokenStore:   tokenStore,
+		emailService: mockEmail,
+		rateLimiter:  ratelimit.NewLimiter(3, 60*time.Minute),
+		opts: &options.Opts{
+			ResetIdentifierMode:     options.ResetIdentifierUsername,
+			ResetTokenExpiryMinutes: 15,
+		},
+	}
+
+	// Attacker tries to pre-exhaust the victim's account bucket by typing the
+	// raw bucket key. Resolution fails (no such username), generic success.
+	for range 3 {
+		result, err := handler.requestPasswordReset([]string{"account:jdoe"})
+		require.NoError(t, err)
+		require.Equal(t, []string{msgResetEmailSent}, result)
+	}
+	require.Zero(t, tokenStore.Count())
+
+	// The victim's own request must still go through.
+	_, err := handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Equal(t, "john.doe@example.com", mockEmail.lastTo, "victim's reset must not be denied")
+	require.Equal(t, 1, tokenStore.Count())
+}
+
 // TestRequestPasswordResetEmptyModeDefaultsToEmail: an unset mode behaves like
 // email-only (backward compatible).
 func TestRequestPasswordResetEmptyModeDefaultsToEmail(t *testing.T) {

--- a/internal/rpchandler/identifier_mode_internal_test.go
+++ b/internal/rpchandler/identifier_mode_internal_test.go
@@ -150,6 +150,44 @@ func TestRequestPasswordResetDuplicatedMail(t *testing.T) {
 	require.Zero(t, tokenStore.Count())
 }
 
+// TestRequestPasswordResetAccountRateLimitAcrossIdentifiers: in "both" mode
+// the email and username spellings of one account must share a rate-limit
+// budget — the typed-string buckets alone would double the reset emails
+// deliverable to a single mailbox.
+func TestRequestPasswordResetAccountRateLimitAcrossIdentifiers(t *testing.T) {
+	tokenStore := resettoken.NewStore()
+	mockEmail := &mockEmailService{}
+	user := &ldap.User{SAMAccountName: "jdoe", Mail: strptr("john.doe@example.com")}
+	mockLDAP := &mockLDAPClient{
+		users:      map[string]*ldap.User{"john.doe@example.com": user},
+		usersBySAM: map[string]*ldap.User{"jdoe": user},
+	}
+	handler := &Handler{
+		ldap:         mockLDAP,
+		tokenStore:   tokenStore,
+		emailService: mockEmail,
+		rateLimiter:  ratelimit.NewLimiter(3, 60*time.Minute),
+		opts: &options.Opts{
+			ResetIdentifierMode:     options.ResetIdentifierBoth,
+			ResetTokenExpiryMinutes: 15,
+		},
+	}
+
+	// Exhaust the account's budget via the email spelling.
+	for i := range 3 {
+		_, err := handler.requestPasswordReset([]string{"john.doe@example.com"})
+		require.NoError(t, err, "request %d", i+1)
+	}
+	require.Equal(t, 3, tokenStore.Count())
+
+	// The username spelling hits a fresh typed-string bucket but must be
+	// stopped by the shared per-account bucket: no fourth email.
+	result, err := handler.requestPasswordReset([]string{"jdoe"})
+	require.NoError(t, err)
+	require.Equal(t, []string{msgResetEmailSent}, result, "response stays enumeration-safe")
+	require.Equal(t, 3, tokenStore.Count(), "no additional token past the account budget")
+}
+
 // TestRequestPasswordResetEmptyModeDefaultsToEmail: an unset mode behaves like
 // email-only (backward compatible).
 func TestRequestPasswordResetEmptyModeDefaultsToEmail(t *testing.T) {

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -3,10 +3,20 @@ package rpchandler
 import (
 	"errors"
 	"log/slog"
+	"strings"
 	"time"
 
+	ldap "github.com/netresearch/simple-ldap-go"
+
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/options"
 	"github.com/netresearch/ldap-selfservice-password-changer/internal/resettoken"
 )
+
+// errIdentifierRejected is returned by resolveResetUser when the supplied
+// identifier does not match the configured mode (e.g. a username entered while
+// the form only accepts email addresses). It is treated as "no user" by the
+// caller to preserve the enumeration-safe generic response.
+var errIdentifierRejected = errors.New("identifier rejected for configured reset mode")
 
 // msgResetEmailSent is the enumeration-safe success message always returned
 // for password reset requests, regardless of whether the account exists.
@@ -85,16 +95,29 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 		return genericSuccess, nil
 	}
 
-	// Look up user in LDAP by email to get SAMAccountName/username
-	// This validates the user exists and retrieves their username for the token
-	user, err := h.ldap.FindUserByMail(emailOrUsername)
+	// Resolve the target account according to the configured identifier mode.
+	// The lookup is authoritative server-side; a mismatch, an ambiguous email,
+	// or any LDAP error all collapse to the generic success below.
+	user, viaEmail, err := h.resolveResetUser(emailOrUsername)
 	if err != nil {
-		// User not found or LDAP error - return generic success (don't reveal)
-		slog.Info("password_reset_user_not_found", "email", emailOrUsername, "error", err)
+		slog.Info("password_reset_user_not_resolved", "identifier", emailOrUsername, "error", err)
 		return genericSuccess, nil
 	}
 
 	username := user.SAMAccountName
+
+	// The reset link is always sent to the account's LDAP-registered address,
+	// never to an arbitrary string typed by the requester. When the user was
+	// found by email, the typed value IS a registered address (LDAP matched a
+	// single account on it); otherwise use the address stored in the directory.
+	recipient := emailOrUsername
+	if !viaEmail {
+		if user.Mail == nil || *user.Mail == "" {
+			slog.Warn("password_reset_no_registered_mail", "username", username)
+			return genericSuccess, nil
+		}
+		recipient = *user.Mail
+	}
 
 	// Create token metadata
 	now := time.Now()
@@ -105,7 +128,7 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 	token := &resettoken.ResetToken{
 		Token:            tokenString,
 		Username:         username,
-		Email:            emailOrUsername,
+		Email:            recipient,
 		CreatedAt:        now,
 		ExpiresAt:        now.Add(expiryDuration),
 		Used:             false,
@@ -120,19 +143,57 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 		return genericSuccess, nil
 	}
 
-	// Send reset email
-	err = h.emailService.SendResetEmail(emailOrUsername, tokenString)
+	// Send reset email to the LDAP-registered address
+	err = h.emailService.SendResetEmail(recipient, tokenString)
 	if err != nil {
 		// Log error internally but return success to user
 		// Token remains in store for potential retry
-		slog.Error("password_reset_email_failed", "username", username, "email", emailOrUsername, "error", err)
+		slog.Error("password_reset_email_failed", "username", username, "email", recipient, "error", err)
 		return genericSuccess, nil
 	}
 
-	slog.Info("password_reset_requested", "username", username, "email", emailOrUsername)
+	slog.Info("password_reset_requested", "username", username, "email", recipient)
 
 	// Return generic success message
 	return genericSuccess, nil
+}
+
+// resolveResetUser looks up the account for a password reset request according
+// to the configured identifier mode. It returns the resolved user, whether the
+// lookup was performed by email (true) or by username (false), and any lookup
+// error. Callers treat every error as "no user" to keep the response
+// enumeration-safe.
+//
+// An empty or unrecognized mode defaults to email-only, matching the behavior
+// before this option existed.
+func (h *Handler) resolveResetUser(identifier string) (user *ldap.User, viaEmail bool, err error) {
+	looksLikeEmail := strings.Contains(identifier, "@")
+
+	mode := h.opts.ResetIdentifierMode
+	if !mode.Valid() {
+		mode = options.ResetIdentifierEmail
+	}
+
+	switch mode {
+	case options.ResetIdentifierUsername:
+		user, err = h.ldap.FindUserBySAMAccountName(identifier)
+		return user, false, err
+	case options.ResetIdentifierBoth:
+		if looksLikeEmail {
+			user, err = h.ldap.FindUserByMail(identifier)
+			return user, true, err
+		}
+		user, err = h.ldap.FindUserBySAMAccountName(identifier)
+		return user, false, err
+	case options.ResetIdentifierEmail:
+		fallthrough
+	default:
+		if !looksLikeEmail {
+			return nil, false, errIdentifierRejected
+		}
+		user, err = h.ldap.FindUserByMail(identifier)
+		return user, true, err
+	}
 }
 
 // ErrSMTPFailure is a placeholder error for SMTP failures in testing scenarios.

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -103,8 +103,11 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 	// Resolve the target account according to the configured identifier mode.
 	// The lookup is authoritative server-side; a mismatch, an ambiguous email,
 	// or any LDAP error all collapse to the generic success below.
+	// The nil-user guard protects against LDAPClient implementations that
+	// return (nil, nil); dereferencing would otherwise panic and break the
+	// enumeration-safe generic response.
 	user, viaEmail, err := h.resolveResetUser(emailOrUsername)
-	if err != nil {
+	if err != nil || user == nil {
 		slog.Info("password_reset_user_not_resolved", "identifier", emailOrUsername, "error", err)
 		return genericSuccess, nil
 	}

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -106,6 +106,18 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 
 	username := user.SAMAccountName
 
+	// THIRD: Check the rate limit for the RESOLVED account. The pre-lookup
+	// check above is keyed on the typed string, so one mailbox reachable via
+	// several identifiers (email and username in "both" mode, or an account
+	// with multiple mail values) would otherwise get one bucket per spelling,
+	// multiplying the reset emails deliverable to it. The "account:" prefix
+	// keeps this bucket disjoint from typed-identifier buckets (":" cannot
+	// occur in a sAMAccountName).
+	if !h.rateLimiter.AllowRequest("account:" + username) {
+		slog.Warn("password_reset_account_rate_limited", "username", username)
+		return genericSuccess, nil
+	}
+
 	// The reset link is always sent to the account's LDAP-registered address,
 	// never to an arbitrary string typed by the requester. When the user was
 	// found by email, the typed value IS a registered address (LDAP matched a

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -81,8 +81,12 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 		return genericSuccess, nil
 	}
 
-	// SECOND: Check email-based rate limit (per-user protection)
-	if !h.rateLimiter.AllowRequest(emailOrUsername) {
+	// SECOND: Check the rate limit for the typed identifier (per-user
+	// protection). The "typed:" prefix keeps these buckets disjoint from the
+	// post-resolution "account:" buckets below — without it, an attacker could
+	// pre-exhaust a victim's account bucket by literally typing
+	// "account:<username>" into the form.
+	if !h.rateLimiter.AllowRequest("typed:" + emailOrUsername) {
 		// User is rate limited - return success but don't proceed
 		slog.Warn("password_reset_rate_limited", "email", emailOrUsername)
 		return genericSuccess, nil
@@ -111,9 +115,9 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 	// check above is keyed on the typed string, so one mailbox reachable via
 	// several identifiers (email and username in "both" mode, or an account
 	// with multiple mail values) would otherwise get one bucket per spelling,
-	// multiplying the reset emails deliverable to it. The "account:" prefix
-	// keeps this bucket disjoint from typed-identifier buckets (":" cannot
-	// occur in a sAMAccountName).
+	// multiplying the reset emails deliverable to it. The "account:"/"typed:"
+	// prefixes keep the two bucket namespaces disjoint, so no typed input can
+	// address an account bucket.
 	if !h.rateLimiter.AllowRequest("account:" + username) {
 		slog.Warn("password_reset_account_rate_limited", "username", username)
 		return genericSuccess, nil

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -2,6 +2,7 @@ package rpchandler
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -178,7 +179,7 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 //
 // An empty or unrecognized mode defaults to email-only, matching the behavior
 // before this option existed.
-func (h *Handler) resolveResetUser(identifier string) (user *ldap.User, viaEmail bool, err error) {
+func (h *Handler) resolveResetUser(identifier string) (*ldap.User, bool, error) {
 	looksLikeEmail := strings.Contains(identifier, "@")
 
 	mode := h.opts.ResetIdentifierMode
@@ -186,26 +187,27 @@ func (h *Handler) resolveResetUser(identifier string) (user *ldap.User, viaEmail
 		mode = options.ResetIdentifierEmail
 	}
 
-	switch mode {
-	case options.ResetIdentifierUsername:
-		user, err = h.ldap.FindUserBySAMAccountName(identifier)
-		return user, false, err
-	case options.ResetIdentifierBoth:
-		if looksLikeEmail {
-			user, err = h.ldap.FindUserByMail(identifier)
-			return user, true, err
+	// Username lookup applies in username-only mode, and in "both" mode when
+	// the input does not look like an email address.
+	if mode == options.ResetIdentifierUsername ||
+		(mode == options.ResetIdentifierBoth && !looksLikeEmail) {
+		user, err := h.ldap.FindUserBySAMAccountName(identifier)
+		if err != nil {
+			return nil, false, fmt.Errorf("find user by sAMAccountName: %w", err)
 		}
-		user, err = h.ldap.FindUserBySAMAccountName(identifier)
-		return user, false, err
-	case options.ResetIdentifierEmail:
-		fallthrough
-	default:
-		if !looksLikeEmail {
-			return nil, false, errIdentifierRejected
-		}
-		user, err = h.ldap.FindUserByMail(identifier)
-		return user, true, err
+		return user, false, nil
 	}
+
+	// Email lookup: in email-only mode a bare username (no "@") is rejected
+	// without an LDAP round-trip.
+	if !looksLikeEmail {
+		return nil, false, errIdentifierRejected
+	}
+	user, err := h.ldap.FindUserByMail(identifier)
+	if err != nil {
+		return nil, true, fmt.Errorf("find user by mail: %w", err)
+	}
+	return user, true, nil
 }
 
 // ErrSMTPFailure is a placeholder error for SMTP failures in testing scenarios.

--- a/internal/rpchandler/request_password_reset_internal_test.go
+++ b/internal/rpchandler/request_password_reset_internal_test.go
@@ -31,7 +31,9 @@ func (m *mockEmailService) SendResetEmail(to, token string) error {
 // Mock LDAP client for testing.
 type mockLDAPClient struct {
 	findUserByMailError error
-	users               map[string]*ldap.User
+	findUserBySAMError  error
+	users               map[string]*ldap.User // keyed by email
+	usersBySAM          map[string]*ldap.User // keyed by sAMAccountName
 }
 
 func (m *mockLDAPClient) FindUserByMail(mail string) (*ldap.User, error) {
@@ -39,6 +41,16 @@ func (m *mockLDAPClient) FindUserByMail(mail string) (*ldap.User, error) {
 		return nil, m.findUserByMailError
 	}
 	if user, ok := m.users[mail]; ok {
+		return user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (m *mockLDAPClient) FindUserBySAMAccountName(sAMAccountName string) (*ldap.User, error) {
+	if m.findUserBySAMError != nil {
+		return nil, m.findUserBySAMError
+	}
+	if user, ok := m.usersBySAM[sAMAccountName]; ok {
 		return user, nil
 	}
 	return nil, errors.New("user not found")

--- a/internal/rpchandler/reset_password_internal_test.go
+++ b/internal/rpchandler/reset_password_internal_test.go
@@ -25,6 +25,10 @@ func (m *mockResetLDAPClient) FindUserByMail(_ string) (*ldap.User, error) {
 	return &ldap.User{SAMAccountName: "testuser"}, nil
 }
 
+func (m *mockResetLDAPClient) FindUserBySAMAccountName(_ string) (*ldap.User, error) {
+	return &ldap.User{SAMAccountName: "testuser"}, nil
+}
+
 func (m *mockResetLDAPClient) ChangePasswordForSAMAccountName(_, _, _ string) error {
 	return m.changePasswordError
 }

--- a/internal/web/static/js/forgot-password-init.ts
+++ b/internal/web/static/js/forgot-password-init.ts
@@ -1,9 +1,15 @@
 /**
  * Forgot password initialization wrapper
- * for CSP compliance (no inline scripts)
+ * for CSP compliance (no inline scripts).
+ *
+ * NOTE: `document.currentScript` is ALWAYS null inside ES modules (per spec),
+ * so we look the script up explicitly by src.
  */
 
 import { init } from "./forgot-password.js";
 
+const currentScript = document.querySelector<HTMLScriptElement>('script[src*="forgot-password-init.js"]');
+const mode = currentScript?.dataset["resetIdentifierMode"] ?? "email";
+
 // Initialize forgot password functionality
-init();
+init(mode);

--- a/internal/web/static/js/forgot-password-init.ts
+++ b/internal/web/static/js/forgot-password-init.ts
@@ -8,7 +8,9 @@
 
 import { init } from "./forgot-password.js";
 
-const currentScript = document.querySelector<HTMLScriptElement>('script[src*="forgot-password-init.js"]');
+// Selected by its config attribute (always rendered by the template) rather
+// than by src, so renaming or cache-busting the bundle cannot break it.
+const currentScript = document.querySelector<HTMLScriptElement>("script[data-reset-identifier-mode]");
 const mode = currentScript?.dataset["resetIdentifierMode"] ?? "email";
 
 // Initialize forgot password functionality

--- a/internal/web/static/js/forgot-password.ts
+++ b/internal/web/static/js/forgot-password.ts
@@ -2,7 +2,27 @@ import { mustNotBeEmpty, isValidEmail } from "./validators.js";
 import { initThemeToggle, initDensityToggle } from "./toggles.js";
 import { type FieldError, setFieldErrors, setSubmitError, updateErrorSummary } from "./error-utils.js";
 
-export const init = () => {
+type IdentifierMode = "email" | "username" | "both";
+
+const asMode = (raw: string): IdentifierMode => (raw === "username" || raw === "both" ? raw : "email");
+
+// Only validate the email format when the value looks like an email; a bare
+// username is accepted as-is. Server-side lookup is authoritative.
+const isValidEmailOrUsername = (v: string): string => (v.includes("@") ? isValidEmail(v) : "");
+
+const identifierField = (mode: IdentifierMode): { label: string; validators: ((v: string) => string)[] } => {
+  switch (mode) {
+    case "username":
+      return { label: "Username", validators: [mustNotBeEmpty("Username")] };
+    case "both":
+      return { label: "Email or Username", validators: [mustNotBeEmpty("Email or username"), isValidEmailOrUsername] };
+    default:
+      return { label: "Email Address", validators: [mustNotBeEmpty("Email"), isValidEmail] };
+  }
+};
+
+export const init = (rawMode: string) => {
+  const mode = asMode(rawMode);
   initThemeToggle();
   initDensityToggle();
 
@@ -30,7 +50,8 @@ export const init = () => {
 
   type Field = [string, string, ((v: string) => string)[]];
 
-  const fieldsWithValidators = [["email", "Email Address", [mustNotBeEmpty("Email"), isValidEmail]]] satisfies Field[];
+  const { label, validators } = identifierField(mode);
+  const fieldsWithValidators = [["email", label, validators]] satisfies Field[];
 
   const fields = fieldsWithValidators.map(([name, label, validators]) => {
     const f = form.querySelector<HTMLDivElement>(`#${name}`);

--- a/internal/web/templates/forgot-password.html
+++ b/internal/web/templates/forgot-password.html
@@ -11,8 +11,12 @@
       {{ template "page-header" }}
 
       <main role="main">
-        {{ template "page-title" (slice "Forgot Password" "Enter your email address to receive a password reset link."
-        "Password Reset Form") }}
+        {{ $mode := printf "%s" .opts.ResetIdentifierMode }}
+        {{ if and (ne $mode "username") (ne $mode "both") }}{{ $mode = "email" }}{{ end }}
+        {{ $noun := "email address" }}
+        {{ if eq $mode "username" }}{{ $noun = "username" }}{{ else if eq $mode "both" }}{{ $noun = "email address or username" }}{{ end }}
+
+        {{ template "page-title" (slice "Forgot Password" (printf "Enter your %s to receive a password reset link." $noun) "Password Reset Form") }}
 
         <form class="space-y-4" id="form" aria-label="Password reset form" autocomplete="on">
           <!-- Error summary for screen readers and focus management (WCAG 3.3.6) -->
@@ -28,13 +32,21 @@
               <span data-purpose="summaryText">Please correct the errors below</span>
             </p>
           </div>
+          {{ if eq $mode "username" }}
+          <!-- prettier-ignore -->
+          {{ template "input" InputOpts "email" "Username" "text" "username" "Enter your username to receive a password reset link" }}
+          {{ else if eq $mode "both" }}
+          <!-- prettier-ignore -->
+          {{ template "input" InputOpts "email" "Email or Username" "text" "username" "Enter your email address or username to receive a password reset link" }}
+          {{ else }}
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "email" "Email Address" "email" "email" "Enter your email address to receive a password reset link" }}
+          {{ end }}
 
           {{ template "form-submit" "Send Reset Link" }}
         </form>
 
-        {{ template "success-message" "If an account exists with this email, a password reset link has been sent." }}
+        {{ template "success-message" "If a matching account exists, a password reset link has been sent to its registered email address." }}
 
         <div class="comfortable:mt-6 compact:mt-4">{{ template "button-secondary" (slice "/" "Back to Login") }}</div>
       </main>
@@ -43,6 +55,11 @@
     </div>
 
     <!-- External script for CSP compliance -->
-    <script type="module" src="/static/js/forgot-password-init.js" defer></script>
+    <script
+      type="module"
+      src="/static/js/forgot-password-init.js"
+      data-reset-identifier-mode="{{ .opts.ResetIdentifierMode }}"
+      defer
+    ></script>
   </body>
 </html>

--- a/internal/web/templates/templates.go
+++ b/internal/web/templates/templates.go
@@ -164,9 +164,12 @@ func RenderIndex(opts *options.Opts) ([]byte, error) {
 	return renderTemplate("index", rawIndex, data)
 }
 
-// RenderForgotPassword renders the password reset request page.
-func RenderForgotPassword() ([]byte, error) {
-	return renderTemplate("forgot-password", rawForgotPassword, nil)
+// RenderForgotPassword renders the password reset request page with the provided configuration options.
+func RenderForgotPassword(opts *options.Opts) ([]byte, error) {
+	data := map[string]any{
+		"opts": opts,
+	}
+	return renderTemplate("forgot-password", rawForgotPassword, data)
 }
 
 // RenderResetPassword renders the password reset completion page with the provided configuration options.

--- a/internal/web/templates/templates.go
+++ b/internal/web/templates/templates.go
@@ -71,6 +71,9 @@ const (
 	inputTypeEmail    = "email"
 )
 
+// optsKey is the template data key exposing configuration options.
+const optsKey = "opts"
+
 // InputOpts holds configuration for rendering HTML input fields with validation and accessibility attributes.
 type InputOpts struct {
 	Name         string
@@ -159,7 +162,7 @@ func renderTemplate(templateName, rawTemplate string, data any) ([]byte, error) 
 // RenderIndex renders the main password change page with the provided configuration options.
 func RenderIndex(opts *options.Opts) ([]byte, error) {
 	data := map[string]any{
-		"opts": opts,
+		optsKey: opts,
 	}
 	return renderTemplate("index", rawIndex, data)
 }
@@ -167,7 +170,7 @@ func RenderIndex(opts *options.Opts) ([]byte, error) {
 // RenderForgotPassword renders the password reset request page with the provided configuration options.
 func RenderForgotPassword(opts *options.Opts) ([]byte, error) {
 	data := map[string]any{
-		"opts": opts,
+		optsKey: opts,
 	}
 	return renderTemplate("forgot-password", rawForgotPassword, data)
 }
@@ -175,7 +178,7 @@ func RenderForgotPassword(opts *options.Opts) ([]byte, error) {
 // RenderResetPassword renders the password reset completion page with the provided configuration options.
 func RenderResetPassword(opts *options.Opts) ([]byte, error) {
 	data := map[string]any{
-		"opts": opts,
+		optsKey: opts,
 	}
 	return renderTemplate("reset-password", rawResetPassword, data)
 }

--- a/internal/web/templates/templates_test.go
+++ b/internal/web/templates/templates_test.go
@@ -401,7 +401,7 @@ func TestRenderTemplateValidHTML(t *testing.T) {
 			},
 		},
 		{
-			name:   "forgot-password",
+			name: "forgot-password",
 			render: func() ([]byte, error) {
 				return RenderForgotPassword(opts)
 			},

--- a/internal/web/templates/templates_test.go
+++ b/internal/web/templates/templates_test.go
@@ -201,7 +201,7 @@ func TestRenderIndex(t *testing.T) {
 
 // TestRenderForgotPassword tests the RenderForgotPassword function.
 func TestRenderForgotPassword(t *testing.T) {
-	result, err := RenderForgotPassword()
+	result, err := RenderForgotPassword(&options.Opts{})
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 
@@ -314,10 +314,10 @@ func TestRenderIndexIdempotent(t *testing.T) {
 
 // TestRenderForgotPasswordIdempotent tests that RenderForgotPassword produces consistent output.
 func TestRenderForgotPasswordIdempotent(t *testing.T) {
-	result1, err1 := RenderForgotPassword()
+	result1, err1 := RenderForgotPassword(&options.Opts{})
 	require.NoError(t, err1)
 
-	result2, err2 := RenderForgotPassword()
+	result2, err2 := RenderForgotPassword(&options.Opts{})
 	require.NoError(t, err2)
 
 	assert.Equal(t, result1, result2, "RenderForgotPassword should produce identical output")
@@ -402,7 +402,9 @@ func TestRenderTemplateValidHTML(t *testing.T) {
 		},
 		{
 			name:   "forgot-password",
-			render: RenderForgotPassword,
+			render: func() ([]byte, error) {
+				return RenderForgotPassword(opts)
+			},
 		},
 		{
 			name: "reset-password",
@@ -478,7 +480,7 @@ func BenchmarkRenderIndex(b *testing.B) {
 func BenchmarkRenderForgotPassword(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = RenderForgotPassword() //nolint:errcheck // benchmark
+		_, _ = RenderForgotPassword(&options.Opts{}) //nolint:errcheck // benchmark
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func registerCorePages(app *fiber.App, index []byte, rpcHandle rpcHandleFunc) {
 // registerResetPages registers the password reset pages when the feature is
 // enabled. Returns any template rendering errors.
 func registerResetPages(app *fiber.App, opts *options.Opts) error {
-	forgotPasswordPage, err := templates.RenderForgotPassword()
+	forgotPasswordPage, err := templates.RenderForgotPassword(opts)
 	if err != nil {
 		return fmt.Errorf("render forgot-password page: %w", err)
 	}


### PR DESCRIPTION
Closes #617.

Active Directory does not enforce a unique `mail` attribute. When several accounts share one address, `FindUserByMail` returns `ErrMailDuplicated` and the forgot-password form silently no-ops for every affected account — no token, no email, generic success (see #617).

## Change

New setting `RESET_IDENTIFIER_MODE` / `--reset-identifier-mode`:

| Value | Form accepts | Lookup |
|---|---|---|
| `email` (default) | email address | `FindUserByMail` — unchanged behavior |
| `username` | username | `FindUserBySAMAccountName` |
| `both` | one combined field | `@` present → mail, else sAMAccountName |

The form label, input type, autocomplete, and client validators adapt to the mode (injected via data attribute, CSP-compliant).

## Security

- The reset link is always sent to the account's **LDAP-registered** address, never to the typed identifier (regression-tested per mode).
- Responses stay enumeration-safe: unknown identifier, ambiguous shared email, mode mismatch, and missing registered mail all return the same generic success.
- Rate limiting now uses three disjoint bucket namespaces: per IP, per typed identifier (`typed:`), and per resolved account (`account:`) — one mailbox reachable via two spellings cannot receive a doubled email budget, and typed input cannot address an account bucket.
- Username lookup escapes its LDAP filter (`ldap.EscapeFilter` in simple-ldap-go), same as the mail path.
- A `(nil, nil)` return from an `LDAPClient` implementation is treated as a lookup failure instead of panicking (defensive guard, regression-tested).
- An ambiguous shared email in `email`/`both` mode intentionally stays a silent generic success; affected users reset via their unique username.

## Not included

- UPN-style logins (`user@domain`) route to the mail lookup in `both` mode; sAMAccountName cannot contain `@`, so this only matters if UPN support is wanted later.
- No "email ambiguous → ask for username" two-step flow: it would leak that an address exists and is shared.

## Testing

- Mode routing, recipient invariant, duplicated-mail, missing-mail, rate-limit namespace isolation: `internal/rpchandler/identifier_mode_internal_test.go`
- Options parsing/normalization/rejection: `internal/options/app_test.go`
- Gates: `go test -race`, `go vet`, `golangci-lint` (0 issues), `tsc` strict, prettier
