### PR TITLE
chore: dependency and code upgrade sweep (2026-07)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - gocyclo # Compute cyclomatic complexities
     - godot # Check comment sentences end with period
     - gomoddirectives # Manage replace/retract directives in go.mod
-    - gomodguard # Control allowed modules
+    - gomodguard_v2 # Control allowed modules
     - goprintffuncname # Check printf-like function names
     - gosec # Security problems (G*)
     - intrange # Find places where for loops could use Go 1.22+ integer range

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -5,6 +5,7 @@ const config = {
   tabWidth: 2,
   semi: true,
   singleQuote: false,
+  tailwindStylesheet: "./internal/web/tailwind.css",
   plugins: ["prettier-plugin-tailwindcss", "prettier-plugin-go-template"]
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "prettier-plugin-go-template": "^0.0.15",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.2",
-        "typescript": "^7.0.0",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.63.0",
       },
     },
@@ -120,46 +120,6 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.63.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.63.0", "@typescript-eslint/types": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.63.0", "", { "dependencies": { "@typescript-eslint/types": "8.63.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw=="],
-
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -509,7 +469,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.63.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.63.0", "@typescript-eslint/parser": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,9 @@
       },
     },
   },
+  "overrides": {
+    "brace-expansion": "^5.0.7",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -180,7 +183,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,13 +7,10 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/postcss": "^4.3.2",
-        "autoprefixer": "^10.5.2",
-        "cssnano": "^8.0.2",
         "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
         "postcss": "^8.5.19",
         "postcss-cli": "^11.0.1",
-        "postcss-nested": "^7.0.2",
         "prettier": "^3.9.5",
         "prettier-plugin-go-template": "^0.0.15",
         "prettier-plugin-tailwindcss": "^0.8.0",
@@ -28,8 +25,6 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
-    "@colordx/core": ["@colordx/core@5.4.3", "", {}, "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -133,25 +128,13 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "autoprefixer": ["autoprefixer@10.5.2", "", { "dependencies": { "browserslist": "^4.28.4", "caniuse-lite": "^1.0.30001799", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q=="],
-
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
-
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
-
-    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "browserslist": ["browserslist@4.28.5", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001800", "electron-to-chromium": "^1.5.387", "node-releases": "^2.0.50", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ=="],
-
-    "caniuse-api": ["caniuse-api@4.0.0", "", { "dependencies": { "browserslist": "^4.0.0", "caniuse-lite": "^1.0.0" } }, "sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA=="],
-
-    "caniuse-lite": ["caniuse-lite@1.0.30001802", "", {}, "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -161,25 +144,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
-
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
-
-    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
-
-    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
-
-    "cssesc": ["cssesc@3.0.0", "", { "bin": "bin/cssesc" }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "cssnano": ["cssnano@8.0.2", "", { "dependencies": { "cssnano-preset-default": "^8.0.2", "lilconfig": "^3.1.3" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-K+a76gA1v0/CsYgcsE95HGGyIuPKxpQSetwSwz4nHEM8fFXqSkzq2JzEXFL8v5+CCjxzVVVhPcTK3Oo8SaF/xA=="],
-
-    "cssnano-preset-default": ["cssnano-preset-default@8.0.2", "", { "dependencies": { "browserslist": "^4.28.2", "cssnano-utils": "^6.0.1", "postcss-calc": "^10.1.1", "postcss-colormin": "^8.0.1", "postcss-convert-values": "^8.0.1", "postcss-discard-comments": "^8.0.1", "postcss-discard-duplicates": "^8.0.1", "postcss-discard-empty": "^8.0.1", "postcss-discard-overridden": "^8.0.1", "postcss-merge-longhand": "^8.0.1", "postcss-merge-rules": "^8.0.1", "postcss-minify-font-values": "^8.0.1", "postcss-minify-gradients": "^8.0.1", "postcss-minify-params": "^8.0.1", "postcss-minify-selectors": "^8.0.2", "postcss-normalize-charset": "^8.0.1", "postcss-normalize-display-values": "^8.0.1", "postcss-normalize-positions": "^8.0.1", "postcss-normalize-repeat-style": "^8.0.1", "postcss-normalize-string": "^8.0.1", "postcss-normalize-timing-functions": "^8.0.1", "postcss-normalize-unicode": "^8.0.1", "postcss-normalize-url": "^8.0.1", "postcss-normalize-whitespace": "^8.0.1", "postcss-ordered-values": "^8.0.1", "postcss-reduce-initial": "^8.0.1", "postcss-reduce-transforms": "^8.0.1", "postcss-svgo": "^8.0.1", "postcss-unique-selectors": "^8.0.1" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-+jQAqIKCqMmBjZs7741XkilU93ITZ/EW8gjAkMmujdCzfDkfjrDBv2VqkSu29Fzeig/0rZ3S9IAwfPLlmXEUfQ=="],
-
-    "cssnano-utils": ["cssnano-utils@6.0.1", "", { "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-zk65GIxA8tCjqVk7nTm1mE+ZKxtnxAvU5JSUaBLXbAr3ZF7IOvz3fbPOnEDvZKhnS7GOIitXTS5BgehLzNoc8Q=="],
-
-    "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -189,21 +154,9 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
-
-    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
-
-    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
-
-    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
-
-    "electron-to-chromium": ["electron-to-chromium@1.5.387", "", {}, "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ=="],
-
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
-
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -244,8 +197,6 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
-
-    "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
@@ -317,8 +268,6 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
-
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -327,11 +276,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
-
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
-
-    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -351,71 +296,11 @@
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
-    "postcss-calc": ["postcss-calc@10.1.1", "", { "dependencies": { "postcss-selector-parser": "^7.0.0", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.4.38" } }, "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw=="],
-
     "postcss-cli": ["postcss-cli@11.0.1", "", { "dependencies": { "chokidar": "^3.3.0", "dependency-graph": "^1.0.0", "fs-extra": "^11.0.0", "picocolors": "^1.0.0", "postcss-load-config": "^5.0.0", "postcss-reporter": "^7.0.0", "pretty-hrtime": "^1.0.3", "read-cache": "^1.0.0", "slash": "^5.0.0", "tinyglobby": "^0.2.12", "yargs": "^17.0.0" }, "peerDependencies": { "postcss": "^8.0.0" }, "bin": { "postcss": "index.js" } }, "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g=="],
-
-    "postcss-colormin": ["postcss-colormin@8.0.1", "", { "dependencies": { "@colordx/core": "^5.4.3", "browserslist": "^4.28.2", "caniuse-api": "^4.0.0", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-qBY4ABQ6d8/mk5RRZHwMllrZMxeMey3azVY2dZUEk+RgiUC4ARdPR3/AITzNqqKTbvW/3y/MJKinDrzwqn8RDQ=="],
-
-    "postcss-convert-values": ["postcss-convert-values@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-IdOSIX3BzfMvCc1TAHIha2gfy17xnb5vfML8e2BIKARnFOghksESfaSAB/3CXgyLfMozZAbTRPVQF5dbuKOidw=="],
-
-    "postcss-discard-comments": ["postcss-discard-comments@8.0.1", "", { "dependencies": { "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-FDvzm3tXlEsQBO2XQgnta5ugsAqwBrgWH+j5QgXpegEIDYA0VPnZg2aP7LtmWtC49POskeIhXesFiU/k3NyFHA=="],
-
-    "postcss-discard-duplicates": ["postcss-discard-duplicates@8.0.1", "", { "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-stTDXkI8YkCUfADurQhp03oq5ynsgSx6Qrw5B1swds6oTHtAeOZ9I0SHGK8cY/VpWUsIYFDWMs3IWf9jIEfFvA=="],
-
-    "postcss-discard-empty": ["postcss-discard-empty@8.0.1", "", { "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-Zv4fM1Yfhk71tbt6gfiptbL6jDHi+7apSnaMeaO9n1uET+1embrXQw5m93Zp5x28UyQSuv+AVkFY193jdwZ33w=="],
-
-    "postcss-discard-overridden": ["postcss-discard-overridden@8.0.1", "", { "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-ykt4fvrC7yYGzbxKyqBVjDCbsjF/11JgWK8enrdkobRyqqEtb/uDUCbKOGdvrK8X7BrShW8Lv5cCRNbdkNHGkQ=="],
 
     "postcss-load-config": ["postcss-load-config@5.1.0", "", { "dependencies": { "lilconfig": "^3.1.1", "yaml": "^2.4.2" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1" }, "optionalPeers": ["tsx"] }, "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA=="],
 
-    "postcss-merge-longhand": ["postcss-merge-longhand@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0", "stylehacks": "^8.0.1" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-huTfSYgQ13O81SFvAuOi7GWnO48vvybjj3xF+X3qUoPjzvvaLpJH5DcUqqXcwOEulZUcvaV4s0V9WtWs+IAQPA=="],
-
-    "postcss-merge-rules": ["postcss-merge-rules@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-api": "^4.0.0", "cssnano-utils": "^6.0.1", "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-o3rk4UpnPNg469tklYwbR/NtvKc/f/wJiVDTnNQ/EFPw/LeiPOHUCvV1GIBQIZHGrBAYdPjToK6a+ojYprsrxQ=="],
-
-    "postcss-minify-font-values": ["postcss-minify-font-values@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-L8Nzs/PRlBSPrLdY/7rAiU5ZN5800+2J/4LRbfyG8SJnPljmgMaXVmQiCklvRS+yObfVRNtvmk/Ean/eoYcSeg=="],
-
-    "postcss-minify-gradients": ["postcss-minify-gradients@8.0.1", "", { "dependencies": { "@colordx/core": "^5.4.3", "cssnano-utils": "^6.0.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-qf+4s/hZMqTwpWN2teqf6+1yvR/SZK5HgHqXYuACeJXV7ABe7AXtBEomgxagUzcN4bSnmqBh5vnIml0dYqykYg=="],
-
-    "postcss-minify-params": ["postcss-minify-params@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "cssnano-utils": "^6.0.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-L0h3H59deFfFg0wQN1NVaS/8E/LfGvaMuZKGO7siwlG995zo3OshtQyRkqKdVqcBwAORBvZ1nDZrKPLRapYkQw=="],
-
-    "postcss-minify-selectors": ["postcss-minify-selectors@8.0.2", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-api": "^4.0.0", "cssesc": "^3.0.0", "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-3icdxc/zght5UAizdwqZBDE2KOWHf1jMQCxET6iLACeNlRxfTPyXS0/COpGk8CQ2cECyaEKTRUd/i/k8Gxmz4g=="],
-
-    "postcss-nested": ["postcss-nested@7.0.2", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw=="],
-
-    "postcss-normalize-charset": ["postcss-normalize-charset@8.0.1", "", { "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-xzqr36F8UeIZOvOHsf3aul+RVJCADvSwuwpMLgizqKjisHZpBfztgW0XFLBfJvz9pJgaStaOXAtGb0zLqT6B0w=="],
-
-    "postcss-normalize-display-values": ["postcss-normalize-display-values@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-ZDWOijOK1FFMlpgiQCUO9fCNKd7HJ9L7z9HWEq4iyubnUFWzdTSwm/LcrMbNW6iZ1oAtqeLYA0WA3xHszOI08g=="],
-
-    "postcss-normalize-positions": ["postcss-normalize-positions@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-uuivan2poSqbE48ST4do20dGaFUeXey9/H8rhHzoyVHB2I6BmkoVLZ/C9+BRjUlpaAFYVOoDY7epkiidzaYbvA=="],
-
-    "postcss-normalize-repeat-style": ["postcss-normalize-repeat-style@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-q2hq5fmKxk29K6DjKA3nZ17Q2dtjhLYFNmFweKALmooUqx6UWAHF1bBoWTu/EqlJ88josb82A/J0Atj9LJUmpQ=="],
-
-    "postcss-normalize-string": ["postcss-normalize-string@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-+Wf+kQJhm1WgSGEAuUaswE9rdpR9QbrKRVemcVHs6rhOoOTVIdAbgaicftfYA6vLM346P8onRzkEVbFN29ktKQ=="],
-
-    "postcss-normalize-timing-functions": ["postcss-normalize-timing-functions@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-W8/tvwRlm3T+yjGkg0IRTF4bvHj0vILYr/LOogCrJKHz2ey2HFRwfsAA8Bk9N4BGR7z7WmmDu/KzzwhJ6FoGPQ=="],
-
-    "postcss-normalize-unicode": ["postcss-normalize-unicode@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-Ad0YHNRBp4WHEOYUM/4wL/8MoL2fimEF8se/0q+Rt/owMzYpbxsypC1P8fN/oluwoRmRKdNVX7X2oycEobPWcQ=="],
-
-    "postcss-normalize-url": ["postcss-normalize-url@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-tkYcip6pCDY806xuxpJYqMW2M3/623jzGFJmz3m5Us47q8P28+gbRZxaea3Rr/CmwwLUiVlh+BTGYwQ6gvaP8A=="],
-
-    "postcss-normalize-whitespace": ["postcss-normalize-whitespace@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-XzORadNfSrKWDZZpgAEHPKINKx8r9r9RIfE9c70g/HThdpbmPHhDYCodHSVESDxmKeySAYw1p4liuBCf7j6LyA=="],
-
-    "postcss-ordered-values": ["postcss-ordered-values@8.0.1", "", { "dependencies": { "cssnano-utils": "^6.0.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-OLXq5lR1yk3KWQ1FPK6aWjFFdktHE9f9kb8cnt4LmIw7w30DnzgD9+sOVYJc5HenkWCX8i1MJhhFwmqc/GYqLg=="],
-
-    "postcss-reduce-initial": ["postcss-reduce-initial@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-api": "^4.0.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-+aQsR6+61KRoIfcFNLP3v9RM7+0iYOTtPnjl1wr6JqMW1zx6S+t2ktHRefXwacFdHIDj5+ETG0KY7K3+SGQ4Nw=="],
-
-    "postcss-reduce-transforms": ["postcss-reduce-transforms@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-x71slHVykiFi5RuKEXM0wgYpY2PngC78x6R8TnZhHF3lhqt+u/w3MGwYLX+2t5O87ssRiMfEAhQH+3J4QwVzCw=="],
-
     "postcss-reporter": ["postcss-reporter@7.1.0", "", { "dependencies": { "picocolors": "^1.0.0", "thenby": "^1.3.4" }, "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA=="],
-
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
-
-    "postcss-svgo": ["postcss-svgo@8.0.1", "", { "dependencies": { "postcss-value-parser": "^4.2.0", "svgo": "^4.0.1" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-HpnvWii7W0/FPrsejJa6ZTi0kNtTJP/Iba7CUMPX0xPV6QpnndOp+SDP74tFtgjA2cYKYNWJPOlmLXMsvi/9yA=="],
-
-    "postcss-unique-selectors": ["postcss-unique-selectors@8.0.1", "", { "dependencies": { "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-+xvKI5+/Cl8yYQwxDV39Uhuc4WV951xngFvPPjiPj2NIbIfm6vbbRTXblyw0FioLkIoGlw+7qUcY1h2YhaZYgw=="],
-
-    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -435,8 +320,6 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
-    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
-
     "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -450,10 +333,6 @@
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "stylehacks": ["stylehacks@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA=="],
-
-    "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
@@ -477,11 +356,7 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
-
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -519,122 +394,8 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "caniuse-api/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "caniuse-api/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "cssnano-preset-default/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
-
-    "postcss-colormin/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-convert-values/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-discard-comments/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
-    "postcss-merge-rules/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-merge-rules/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
-    "postcss-minify-params/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-minify-selectors/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-minify-selectors/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
-    "postcss-normalize-unicode/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-reduce-initial/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "postcss-unique-selectors/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "stylehacks/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "stylehacks/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
-    "caniuse-api/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "caniuse-api/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "caniuse-api/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "cssnano-preset-default/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "cssnano-preset-default/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "cssnano-preset-default/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "cssnano-preset-default/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
-
-    "postcss-colormin/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-colormin/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-colormin/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-colormin/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-convert-values/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-convert-values/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-convert-values/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-convert-values/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-merge-rules/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-merge-rules/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-merge-rules/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-merge-rules/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-minify-params/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-minify-params/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-minify-params/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-minify-params/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-minify-selectors/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-minify-selectors/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-minify-selectors/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-minify-selectors/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-normalize-unicode/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-normalize-unicode/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-normalize-unicode/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-normalize-unicode/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "postcss-reduce-initial/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "postcss-reduce-initial/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "postcss-reduce-initial/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "postcss-reduce-initial/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
-
-    "stylehacks/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": "dist/cli.cjs" }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
-
-    "stylehacks/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
-
-    "stylehacks/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
-
-    "stylehacks/browserslist/node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
   }
 }

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -469,8 +469,7 @@ uglify-js             # Minify for production
 
 ```bash
 postcss               # Process Tailwind directives
-autoprefixer          # Add vendor prefixes
-cssnano              # Minify for production
+@tailwindcss/postcss  # Prefixing, nesting, minification via Lightning CSS
 ```
 
 **Build Scripts** (`package.json`):
@@ -520,8 +519,7 @@ var staticFS embed.FS
 - `typescript` - Type-safe JavaScript
 - `@tailwindcss/postcss` - CSS framework
 - `uglify-js` - JavaScript minification
-- `postcss` - CSS processing
-- `cssnano` - CSS minification
+- `postcss` - CSS processing (minification via @tailwindcss/postcss / Lightning CSS)
 
 **Development**:
 
@@ -588,7 +586,7 @@ var staticFS embed.FS
 
 ### Frontend
 
-- **Asset minification**: UglifyJS and cssnano
+- **Asset minification**: Lightning CSS via `@tailwindcss/postcss` (no JS minifier configured)
 - **HTTP/2**: Parallel asset loading
 - **Lazy loading**: Module imports for page-specific code
 - **PWA**: Offline capability with service worker

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -401,7 +401,6 @@ ldap-selfservice-password-changer/
 ├── package.json                     # Node.js dependencies
 ├── pnpm-lock.yaml                   # pnpm lock file
 ├── tsconfig.json                    # TypeScript configuration
-├── tailwind.config.js               # Tailwind CSS configuration
 ├── postcss.config.js                # PostCSS configuration
 ├── .prettierrc.mjs                  # Prettier configuration
 ├── .prettierignore                  # Prettier ignore patterns

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,12 @@
 // ESLint flat config for TypeScript/JavaScript
 // https://eslint.org/docs/latest/use/configure/configuration-files
 
+import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 
-export default tseslint.config(
+export default defineConfig(
   // Global ignores
   {
     ignores: [
@@ -29,15 +30,10 @@ export default tseslint.config(
   },
 
   // TypeScript strict type-checked configuration (only for TS files)
-  ...tseslint.configs.strictTypeChecked.map((config) => ({
-    ...config,
-    files: ["**/*.ts", "**/*.tsx"]
-  })),
-
-  ...tseslint.configs.stylisticTypeChecked.map((config) => ({
-    ...config,
-    files: ["**/*.ts", "**/*.tsx"]
-  })),
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    extends: [tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked]
+  },
 
   // Project-specific TypeScript settings
   {

--- a/internal/ratelimit/ip_limiter_internal_test.go
+++ b/internal/ratelimit/ip_limiter_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -286,45 +287,49 @@ func TestMixedIPv4IPv6(t *testing.T) {
 
 // TestIPLimiterStartCleanup tests the StartCleanup method on IPLimiter.
 func TestIPLimiterStartCleanup(t *testing.T) {
-	// Create an IPLimiter that wraps a Limiter
-	limiter := NewIPLimiter()
+	synctest.Test(t, func(t *testing.T) {
+		// Create an IPLimiter that wraps a Limiter
+		limiter := NewIPLimiter()
 
-	// Add some entries
-	limiter.AllowRequest("192.168.1.1")
-	limiter.AllowRequest("192.168.1.2")
+		// Add some entries
+		limiter.AllowRequest("192.168.1.1")
+		limiter.AllowRequest("192.168.1.2")
 
-	if limiter.Count() != 2 {
-		t.Errorf("Count = %d, want 2", limiter.Count())
-	}
+		if limiter.Count() != 2 {
+			t.Errorf("Count = %d, want 2", limiter.Count())
+		}
 
-	// Start cleanup goroutine
-	stop := limiter.StartCleanup(50 * time.Millisecond)
-	defer close(stop)
+		// Start cleanup goroutine
+		stop := limiter.StartCleanup(50 * time.Millisecond)
+		defer close(stop)
 
-	// Let it run briefly (entries won't expire since window is 60 minutes)
-	time.Sleep(100 * time.Millisecond)
+		// Let it run briefly (entries won't expire since window is 60 minutes)
+		time.Sleep(100 * time.Millisecond)
 
-	// Entries should still be there (not expired)
-	if limiter.Count() != 2 {
-		t.Errorf("Count after cleanup = %d, want 2 (not expired)", limiter.Count())
-	}
+		// Entries should still be there (not expired)
+		if limiter.Count() != 2 {
+			t.Errorf("Count after cleanup = %d, want 2 (not expired)", limiter.Count())
+		}
+	})
 }
 
 // TestIPLimiterStartCleanupStop tests stopping the cleanup goroutine.
 func TestIPLimiterStartCleanupStop(t *testing.T) {
-	limiter := NewIPLimiter()
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewIPLimiter()
 
-	// Start cleanup
-	stop := limiter.StartCleanup(10 * time.Millisecond)
+		// Start cleanup
+		stop := limiter.StartCleanup(10 * time.Millisecond)
 
-	// Let it run briefly
-	time.Sleep(50 * time.Millisecond)
+		// Let it run briefly
+		time.Sleep(50 * time.Millisecond)
 
-	// Stop the goroutine
-	close(stop)
+		// Stop the goroutine
+		close(stop)
 
-	// Wait to ensure goroutine terminates
-	time.Sleep(30 * time.Millisecond)
+		// Wait to ensure goroutine terminates
+		time.Sleep(30 * time.Millisecond)
 
-	// Test passes if no panic/hang
+		// Test passes if no panic/hang
+	})
 }

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"slices"
 	"sync"
 	"time"
 )
@@ -69,13 +70,9 @@ func (l *Limiter) AllowRequest(identifier string) bool {
 	}
 
 	// Remove timestamps outside the window (sliding window)
-	validTimestamps := []time.Time{}
-	for _, ts := range entry.timestamps {
-		if ts.After(cutoff) {
-			validTimestamps = append(validTimestamps, ts)
-		}
-	}
-	entry.timestamps = validTimestamps
+	entry.timestamps = slices.DeleteFunc(entry.timestamps, func(ts time.Time) bool {
+		return !ts.After(cutoff)
+	})
 
 	// Check if rate limit exceeded
 	if len(entry.timestamps) >= l.maxRequests {
@@ -105,13 +102,9 @@ func (l *Limiter) cleanupExpiredLocked(cutoff time.Time) int {
 
 	for identifier, entry := range l.entries {
 		// Check if all timestamps are expired
-		allExpired := true
-		for _, ts := range entry.timestamps {
-			if ts.After(cutoff) {
-				allExpired = false
-				break
-			}
-		}
+		allExpired := !slices.ContainsFunc(entry.timestamps, func(ts time.Time) bool {
+			return ts.After(cutoff)
+		})
 
 		if allExpired {
 			delete(l.entries, identifier)

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -101,10 +101,10 @@ func (l *Limiter) cleanupExpiredLocked(cutoff time.Time) int {
 	count := 0
 
 	for identifier, entry := range l.entries {
-		// Check if all timestamps are expired
-		allExpired := !slices.ContainsFunc(entry.timestamps, func(ts time.Time) bool {
-			return ts.After(cutoff)
-		})
+		// Timestamps are appended chronologically, so the entry is fully
+		// expired iff its newest (last) timestamp is expired.
+		n := len(entry.timestamps)
+		allExpired := n == 0 || !entry.timestamps[n-1].After(cutoff)
 
 		if allExpired {
 			delete(l.entries, identifier)

--- a/internal/ratelimit/limiter_internal_test.go
+++ b/internal/ratelimit/limiter_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -58,61 +59,65 @@ func TestAllowRequestDifferentUsers(t *testing.T) {
 }
 
 func TestSlidingWindow(t *testing.T) {
-	limiter := NewLimiter(2, 100*time.Millisecond)
-	identifier := testUserEmail
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewLimiter(2, 100*time.Millisecond)
+		identifier := testUserEmail
 
-	// Make 2 requests (limit reached)
-	limiter.AllowRequest(identifier)
-	limiter.AllowRequest(identifier)
+		// Make 2 requests (limit reached)
+		limiter.AllowRequest(identifier)
+		limiter.AllowRequest(identifier)
 
-	// 3rd request should be blocked
-	allowed := limiter.AllowRequest(identifier)
-	if allowed {
-		t.Error("Request should be blocked immediately")
-	}
+		// 3rd request should be blocked
+		allowed := limiter.AllowRequest(identifier)
+		if allowed {
+			t.Error("Request should be blocked immediately")
+		}
 
-	// Wait for window to pass
-	time.Sleep(150 * time.Millisecond)
+		// Wait for window to pass
+		time.Sleep(150 * time.Millisecond)
 
-	// Should be allowed again
-	allowed = limiter.AllowRequest(identifier)
-	if !allowed {
-		t.Error("Request should be allowed after window expired")
-	}
+		// Should be allowed again
+		allowed = limiter.AllowRequest(identifier)
+		if !allowed {
+			t.Error("Request should be allowed after window expired")
+		}
+	})
 }
 
 func TestCleanupExpiredEntries(t *testing.T) {
-	limiter := NewLimiter(3, 100*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewLimiter(3, 100*time.Millisecond)
 
-	// Make requests from multiple users
-	limiter.AllowRequest("user1@example.com")
-	limiter.AllowRequest("user2@example.com")
-	limiter.AllowRequest("user3@example.com")
+		// Make requests from multiple users
+		limiter.AllowRequest("user1@example.com")
+		limiter.AllowRequest("user2@example.com")
+		limiter.AllowRequest("user3@example.com")
 
-	// Verify entries exist
-	limiter.mu.RLock()
-	initialCount := len(limiter.entries)
-	limiter.mu.RUnlock()
-	if initialCount != 3 {
-		t.Errorf("Expected 3 entries, got %d", initialCount)
-	}
+		// Verify entries exist
+		limiter.mu.RLock()
+		initialCount := len(limiter.entries)
+		limiter.mu.RUnlock()
+		if initialCount != 3 {
+			t.Errorf("Expected 3 entries, got %d", initialCount)
+		}
 
-	// Wait for entries to expire
-	time.Sleep(150 * time.Millisecond)
+		// Wait for entries to expire
+		time.Sleep(150 * time.Millisecond)
 
-	// Run cleanup
-	count := limiter.CleanupExpired()
-	if count != 3 {
-		t.Errorf("CleanupExpired() removed %d entries, want 3", count)
-	}
+		// Run cleanup
+		count := limiter.CleanupExpired()
+		if count != 3 {
+			t.Errorf("CleanupExpired() removed %d entries, want 3", count)
+		}
 
-	// Verify entries are gone
-	limiter.mu.RLock()
-	finalCount := len(limiter.entries)
-	limiter.mu.RUnlock()
-	if finalCount != 0 {
-		t.Errorf("Expected 0 entries after cleanup, got %d", finalCount)
-	}
+		// Verify entries are gone
+		limiter.mu.RLock()
+		finalCount := len(limiter.entries)
+		limiter.mu.RUnlock()
+		if finalCount != 0 {
+			t.Errorf("Expected 0 entries after cleanup, got %d", finalCount)
+		}
+	})
 }
 
 func TestConcurrentAccess(t *testing.T) {
@@ -149,26 +154,28 @@ func TestConcurrentAccess(t *testing.T) {
 }
 
 func TestRateLimitReset(t *testing.T) {
-	limiter := NewLimiter(1, 50*time.Millisecond)
-	identifier := "reset@example.com"
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewLimiter(1, 50*time.Millisecond)
+		identifier := "reset@example.com"
 
-	// Make first request (allowed)
-	if !limiter.AllowRequest(identifier) {
-		t.Error("First request should be allowed")
-	}
+		// Make first request (allowed)
+		if !limiter.AllowRequest(identifier) {
+			t.Error("First request should be allowed")
+		}
 
-	// Second request blocked
-	if limiter.AllowRequest(identifier) {
-		t.Error("Second request should be blocked")
-	}
+		// Second request blocked
+		if limiter.AllowRequest(identifier) {
+			t.Error("Second request should be blocked")
+		}
 
-	// Wait for window
-	time.Sleep(60 * time.Millisecond)
+		// Wait for window
+		time.Sleep(60 * time.Millisecond)
 
-	// Should be allowed again
-	if !limiter.AllowRequest(identifier) {
-		t.Error("Request should be allowed after window reset")
-	}
+		// Should be allowed again
+		if !limiter.AllowRequest(identifier) {
+			t.Error("Request should be allowed after window reset")
+		}
+	})
 }
 
 func TestCount(t *testing.T) {
@@ -217,29 +224,31 @@ func TestCapacityEnforcement(t *testing.T) {
 }
 
 func TestCapacityCleanupMakesRoom(t *testing.T) {
-	// Create limiter with short window
-	limiter := NewLimiterWithCapacity(1, 50*time.Millisecond, 50)
+	synctest.Test(t, func(t *testing.T) {
+		// Create limiter with short window
+		limiter := NewLimiterWithCapacity(1, 50*time.Millisecond, 50)
 
-	// Fill to capacity with requests that will expire soon
-	for i := range 50 {
-		identifier := fmt.Sprintf("user%d@example.com", i)
-		limiter.AllowRequest(identifier)
-	}
+		// Fill to capacity with requests that will expire soon
+		for i := range 50 {
+			identifier := fmt.Sprintf("user%d@example.com", i)
+			limiter.AllowRequest(identifier)
+		}
 
-	// Wait for entries to expire
-	time.Sleep(60 * time.Millisecond)
+		// Wait for entries to expire
+		time.Sleep(60 * time.Millisecond)
 
-	// New request should trigger cleanup and succeed
-	allowed := limiter.AllowRequest("new@example.com")
-	if !allowed {
-		t.Error("Request should be allowed after expired entries are cleaned up")
-	}
+		// New request should trigger cleanup and succeed
+		allowed := limiter.AllowRequest("new@example.com")
+		if !allowed {
+			t.Error("Request should be allowed after expired entries are cleaned up")
+		}
 
-	// Verify cleanup occurred
-	count := limiter.Count()
-	if count > 10 {
-		t.Errorf("Count after cleanup = %d, should be much smaller", count)
-	}
+		// Verify cleanup occurred
+		count := limiter.Count()
+		if count > 10 {
+			t.Errorf("Count after cleanup = %d, should be much smaller", count)
+		}
+	})
 }
 
 func TestCapacityFailClosedBehavior(t *testing.T) {

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -3,6 +3,7 @@ package ratelimit_test
 import (
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/netresearch/ldap-selfservice-password-changer/internal/ratelimit"
@@ -50,45 +51,49 @@ func TestAllowRequestDifferentUsers(t *testing.T) {
 }
 
 func TestSlidingWindow(t *testing.T) {
-	limiter := ratelimit.NewLimiter(2, 100*time.Millisecond)
-	identifier := "user@example.com"
+	synctest.Test(t, func(t *testing.T) {
+		limiter := ratelimit.NewLimiter(2, 100*time.Millisecond)
+		identifier := "user@example.com"
 
-	// Make 2 requests (limit reached).
-	limiter.AllowRequest(identifier)
-	limiter.AllowRequest(identifier)
+		// Make 2 requests (limit reached).
+		limiter.AllowRequest(identifier)
+		limiter.AllowRequest(identifier)
 
-	// 3rd request should be blocked.
-	allowed := limiter.AllowRequest(identifier)
-	if allowed {
-		t.Error("Request should be blocked immediately")
-	}
+		// 3rd request should be blocked.
+		allowed := limiter.AllowRequest(identifier)
+		if allowed {
+			t.Error("Request should be blocked immediately")
+		}
 
-	// Wait for window to pass.
-	time.Sleep(150 * time.Millisecond)
+		// Wait for window to pass.
+		time.Sleep(150 * time.Millisecond)
 
-	// Should be allowed again.
-	allowed = limiter.AllowRequest(identifier)
-	if !allowed {
-		t.Error("Request should be allowed after window expired")
-	}
+		// Should be allowed again.
+		allowed = limiter.AllowRequest(identifier)
+		if !allowed {
+			t.Error("Request should be allowed after window expired")
+		}
+	})
 }
 
 func TestCleanupExpired(t *testing.T) {
-	limiter := ratelimit.NewLimiter(3, 100*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		limiter := ratelimit.NewLimiter(3, 100*time.Millisecond)
 
-	// Make requests from multiple users.
-	limiter.AllowRequest("user1@example.com")
-	limiter.AllowRequest("user2@example.com")
-	limiter.AllowRequest("user3@example.com")
+		// Make requests from multiple users.
+		limiter.AllowRequest("user1@example.com")
+		limiter.AllowRequest("user2@example.com")
+		limiter.AllowRequest("user3@example.com")
 
-	// Wait for entries to expire.
-	time.Sleep(150 * time.Millisecond)
+		// Wait for entries to expire.
+		time.Sleep(150 * time.Millisecond)
 
-	// Run cleanup.
-	count := limiter.CleanupExpired()
-	if count != 3 {
-		t.Errorf("CleanupExpired() removed %d entries, want 3", count)
-	}
+		// Run cleanup.
+		count := limiter.CleanupExpired()
+		if count != 3 {
+			t.Errorf("CleanupExpired() removed %d entries, want 3", count)
+		}
+	})
 }
 
 func TestCount(t *testing.T) {
@@ -151,76 +156,82 @@ func TestIsFull(t *testing.T) {
 
 // TestStartCleanup tests the StartCleanup goroutine lifecycle.
 func TestStartCleanup(t *testing.T) {
-	limiter := ratelimit.NewLimiter(3, 50*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		limiter := ratelimit.NewLimiter(3, 50*time.Millisecond)
 
-	// Add some entries.
-	limiter.AllowRequest("user1@example.com")
-	limiter.AllowRequest("user2@example.com")
+		// Add some entries.
+		limiter.AllowRequest("user1@example.com")
+		limiter.AllowRequest("user2@example.com")
 
-	if limiter.Count() != 2 {
-		t.Errorf("Count = %d, want 2", limiter.Count())
-	}
+		if limiter.Count() != 2 {
+			t.Errorf("Count = %d, want 2", limiter.Count())
+		}
 
-	// Start cleanup goroutine with short interval.
-	stop := limiter.StartCleanup(60 * time.Millisecond)
-	defer close(stop)
+		// Start cleanup goroutine with short interval.
+		stop := limiter.StartCleanup(60 * time.Millisecond)
+		defer close(stop)
 
-	// Wait for entries to expire.
-	time.Sleep(80 * time.Millisecond)
+		// Wait for entries to expire.
+		time.Sleep(80 * time.Millisecond)
 
-	// Wait for cleanup to run.
-	time.Sleep(80 * time.Millisecond)
+		// Wait for cleanup to run.
+		time.Sleep(80 * time.Millisecond)
 
-	// Entries should be cleaned up.
-	count := limiter.Count()
-	if count != 0 {
-		t.Errorf("Count after cleanup = %d, want 0", count)
-	}
+		// Entries should be cleaned up.
+		count := limiter.Count()
+		if count != 0 {
+			t.Errorf("Count after cleanup = %d, want 0", count)
+		}
+	})
 }
 
 // TestStartCleanupStop tests that stop channel properly terminates cleanup.
 func TestStartCleanupStop(t *testing.T) {
-	limiter := ratelimit.NewLimiter(3, 60*time.Minute)
+	synctest.Test(t, func(t *testing.T) {
+		limiter := ratelimit.NewLimiter(3, 60*time.Minute)
 
-	// Start cleanup with short interval.
-	stop := limiter.StartCleanup(10 * time.Millisecond)
+		// Start cleanup with short interval.
+		stop := limiter.StartCleanup(10 * time.Millisecond)
 
-	// Let it run a few times.
-	time.Sleep(50 * time.Millisecond)
+		// Let it run a few times.
+		time.Sleep(50 * time.Millisecond)
 
-	// Stop the goroutine.
-	close(stop)
+		// Stop the goroutine.
+		close(stop)
 
-	// Wait briefly to ensure goroutine terminates.
-	time.Sleep(20 * time.Millisecond)
+		// Wait briefly to ensure goroutine terminates.
+		time.Sleep(20 * time.Millisecond)
 
-	// Test passed if no panic/hang - goroutine properly terminated.
+		// Test passed if no panic/hang - goroutine properly terminated.
+	})
 }
 
 // TestStartCleanupWithActivity tests cleanup doesn't remove active entries.
 func TestStartCleanupWithActivity(t *testing.T) {
-	limiter := ratelimit.NewLimiter(3, 200*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		limiter := ratelimit.NewLimiter(3, 200*time.Millisecond)
 
-	stop := limiter.StartCleanup(50 * time.Millisecond)
-	defer close(stop)
+		stop := limiter.StartCleanup(50 * time.Millisecond)
+		defer close(stop)
 
-	// Add entries and keep refreshing one of them.
-	limiter.AllowRequest("active@example.com")
-	limiter.AllowRequest("inactive@example.com")
-
-	// Keep "active" user active by making requests.
-	for i := range 4 {
-		time.Sleep(60 * time.Millisecond)
+		// Add entries and keep refreshing one of them.
 		limiter.AllowRequest("active@example.com")
-		if i < 3 {
-			// After first few iterations, inactive should still be there.
-			if limiter.Count() == 0 {
-				t.Error("entries removed too early")
+		limiter.AllowRequest("inactive@example.com")
+
+		// Keep "active" user active by making requests.
+		for i := range 4 {
+			time.Sleep(60 * time.Millisecond)
+			limiter.AllowRequest("active@example.com")
+			if i < 3 {
+				// After first few iterations, inactive should still be there.
+				if limiter.Count() == 0 {
+					t.Error("entries removed too early")
+				}
 			}
 		}
-	}
 
-	// After window expires, cleanup should have run.
-	// Active user should still be tracked (has recent activity).
-	// This test verifies cleanup only removes truly expired entries.
+		// After window expires, cleanup should have run.
+		// Active user should still be tracked (has recent activity).
+		// This test verifies cleanup only removes truly expired entries.
+	})
 }

--- a/internal/resettoken/store_internal_test.go
+++ b/internal/resettoken/store_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -632,151 +633,159 @@ func BenchmarkGetToken(b *testing.B) {
 
 // TestStartCleanupGoroutine tests the StartCleanup function lifecycle.
 func TestStartCleanupGoroutine(t *testing.T) {
-	store := NewStore()
+	synctest.Test(t, func(t *testing.T) {
+		store := NewStore()
 
-	// Add an expired token
-	expiredToken := &ResetToken{
-		Token:     "cleanup-test-expired",
-		Username:  "expired",
-		Email:     "expired@example.com",
-		CreatedAt: time.Now().Add(-20 * time.Minute),
-		ExpiresAt: time.Now().Add(-5 * time.Minute),
-	}
-	err := store.Store(expiredToken)
-	require.NoError(t, err)
+		// Add an expired token
+		expiredToken := &ResetToken{
+			Token:     "cleanup-test-expired",
+			Username:  "expired",
+			Email:     "expired@example.com",
+			CreatedAt: time.Now().Add(-20 * time.Minute),
+			ExpiresAt: time.Now().Add(-5 * time.Minute),
+		}
+		err := store.Store(expiredToken)
+		require.NoError(t, err)
 
-	// Add a valid token
-	validToken := &ResetToken{
-		Token:     "cleanup-test-valid",
-		Username:  "valid",
-		Email:     "valid@example.com",
-		CreatedAt: time.Now(),
-		ExpiresAt: time.Now().Add(15 * time.Minute),
-	}
-	err = store.Store(validToken)
-	require.NoError(t, err)
-
-	// Verify both tokens exist
-	if store.Count() != 2 {
-		t.Errorf("Expected 2 tokens, got %d", store.Count())
-	}
-
-	// Start cleanup with very short interval for testing
-	stop := store.StartCleanup(50 * time.Millisecond)
-
-	// Wait for at least one cleanup cycle
-	time.Sleep(150 * time.Millisecond)
-
-	// Verify expired token was cleaned up
-	if store.Count() != 1 {
-		t.Errorf("Expected 1 token after cleanup, got %d", store.Count())
-	}
-
-	// Verify valid token still exists
-	_, err = store.Get("cleanup-test-valid")
-	require.NoError(t, err, "Valid token should still exist")
-
-	// Stop the cleanup goroutine
-	close(stop)
-
-	// Give goroutine time to exit
-	time.Sleep(100 * time.Millisecond)
-}
-
-// TestStartCleanupStop tests that the cleanup goroutine stops correctly.
-func TestStartCleanupStop(t *testing.T) {
-	store := NewStore()
-
-	// Start cleanup
-	stop := store.StartCleanup(10 * time.Millisecond)
-
-	// Stop immediately
-	close(stop)
-
-	// Add an expired token after stopping
-	expiredToken := &ResetToken{
-		Token:     "post-stop-expired",
-		Username:  "expired",
-		Email:     "expired@example.com",
-		CreatedAt: time.Now().Add(-20 * time.Minute),
-		ExpiresAt: time.Now().Add(-5 * time.Minute),
-	}
-	err := store.Store(expiredToken)
-	require.NoError(t, err)
-
-	// Wait longer than cleanup interval
-	time.Sleep(50 * time.Millisecond)
-
-	// Expired token should still exist because cleanup was stopped
-	if store.Count() != 1 {
-		t.Errorf("Expected 1 token (cleanup should be stopped), got %d", store.Count())
-	}
-}
-
-// TestStartCleanupMultiple tests starting multiple cleanup goroutines.
-func TestStartCleanupMultiple(t *testing.T) {
-	store := NewStore()
-
-	// Start multiple cleanup goroutines (not recommended but should be safe)
-	stop1 := store.StartCleanup(50 * time.Millisecond)
-	stop2 := store.StartCleanup(50 * time.Millisecond)
-
-	// Add an expired token
-	expiredToken := &ResetToken{
-		Token:     "multi-cleanup-expired",
-		Username:  "expired",
-		Email:     "expired@example.com",
-		CreatedAt: time.Now().Add(-20 * time.Minute),
-		ExpiresAt: time.Now().Add(-5 * time.Minute),
-	}
-	err := store.Store(expiredToken)
-	require.NoError(t, err)
-
-	// Wait for cleanup
-	time.Sleep(150 * time.Millisecond)
-
-	// Token should be cleaned up
-	if store.Count() != 0 {
-		t.Errorf("Expected 0 tokens, got %d", store.Count())
-	}
-
-	// Stop both
-	close(stop1)
-	close(stop2)
-
-	// Give goroutines time to exit
-	time.Sleep(100 * time.Millisecond)
-}
-
-// TestStartCleanupNoExpiredTokens tests cleanup when no tokens are expired.
-func TestStartCleanupNoExpiredTokens(t *testing.T) {
-	store := NewStore()
-
-	// Add only valid tokens
-	for i := range 5 {
-		token := &ResetToken{
-			Token:     generateUniqueToken(0, i),
+		// Add a valid token
+		validToken := &ResetToken{
+			Token:     "cleanup-test-valid",
 			Username:  "valid",
 			Email:     "valid@example.com",
 			CreatedAt: time.Now(),
 			ExpiresAt: time.Now().Add(15 * time.Minute),
 		}
-		err := store.Store(token)
+		err = store.Store(validToken)
 		require.NoError(t, err)
-	}
 
-	// Start cleanup
-	stop := store.StartCleanup(50 * time.Millisecond)
+		// Verify both tokens exist
+		if store.Count() != 2 {
+			t.Errorf("Expected 2 tokens, got %d", store.Count())
+		}
 
-	// Wait for at least one cleanup cycle
-	time.Sleep(150 * time.Millisecond)
+		// Start cleanup with very short interval for testing
+		stop := store.StartCleanup(50 * time.Millisecond)
 
-	// All tokens should still exist
-	if store.Count() != 5 {
-		t.Errorf("Expected 5 tokens, got %d", store.Count())
-	}
+		// Wait for at least one cleanup cycle
+		time.Sleep(150 * time.Millisecond)
 
-	close(stop)
+		// Verify expired token was cleaned up
+		if store.Count() != 1 {
+			t.Errorf("Expected 1 token after cleanup, got %d", store.Count())
+		}
+
+		// Verify valid token still exists
+		_, err = store.Get("cleanup-test-valid")
+		require.NoError(t, err, "Valid token should still exist")
+
+		// Stop the cleanup goroutine
+		close(stop)
+
+		// Give goroutine time to exit
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
+// TestStartCleanupStop tests that the cleanup goroutine stops correctly.
+func TestStartCleanupStop(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := NewStore()
+
+		// Start cleanup
+		stop := store.StartCleanup(10 * time.Millisecond)
+
+		// Stop immediately
+		close(stop)
+
+		// Add an expired token after stopping
+		expiredToken := &ResetToken{
+			Token:     "post-stop-expired",
+			Username:  "expired",
+			Email:     "expired@example.com",
+			CreatedAt: time.Now().Add(-20 * time.Minute),
+			ExpiresAt: time.Now().Add(-5 * time.Minute),
+		}
+		err := store.Store(expiredToken)
+		require.NoError(t, err)
+
+		// Wait longer than cleanup interval
+		time.Sleep(50 * time.Millisecond)
+
+		// Expired token should still exist because cleanup was stopped
+		if store.Count() != 1 {
+			t.Errorf("Expected 1 token (cleanup should be stopped), got %d", store.Count())
+		}
+	})
+}
+
+// TestStartCleanupMultiple tests starting multiple cleanup goroutines.
+func TestStartCleanupMultiple(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := NewStore()
+
+		// Start multiple cleanup goroutines (not recommended but should be safe)
+		stop1 := store.StartCleanup(50 * time.Millisecond)
+		stop2 := store.StartCleanup(50 * time.Millisecond)
+
+		// Add an expired token
+		expiredToken := &ResetToken{
+			Token:     "multi-cleanup-expired",
+			Username:  "expired",
+			Email:     "expired@example.com",
+			CreatedAt: time.Now().Add(-20 * time.Minute),
+			ExpiresAt: time.Now().Add(-5 * time.Minute),
+		}
+		err := store.Store(expiredToken)
+		require.NoError(t, err)
+
+		// Wait for cleanup
+		time.Sleep(150 * time.Millisecond)
+
+		// Token should be cleaned up
+		if store.Count() != 0 {
+			t.Errorf("Expected 0 tokens, got %d", store.Count())
+		}
+
+		// Stop both
+		close(stop1)
+		close(stop2)
+
+		// Give goroutines time to exit
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
+// TestStartCleanupNoExpiredTokens tests cleanup when no tokens are expired.
+func TestStartCleanupNoExpiredTokens(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := NewStore()
+
+		// Add only valid tokens
+		for i := range 5 {
+			token := &ResetToken{
+				Token:     generateUniqueToken(0, i),
+				Username:  "valid",
+				Email:     "valid@example.com",
+				CreatedAt: time.Now(),
+				ExpiresAt: time.Now().Add(15 * time.Minute),
+			}
+			err := store.Store(token)
+			require.NoError(t, err)
+		}
+
+		// Start cleanup
+		stop := store.StartCleanup(50 * time.Millisecond)
+
+		// Wait for at least one cleanup cycle
+		time.Sleep(150 * time.Millisecond)
+
+		// All tokens should still exist
+		if store.Count() != 5 {
+			t.Errorf("Expected 5 tokens, got %d", store.Count())
+		}
+
+		close(stop)
+	})
 }
 
 // =============================================================================

--- a/internal/rpchandler/reset_password.go
+++ b/internal/rpchandler/reset_password.go
@@ -3,6 +3,7 @@ package rpchandler
 import (
 	"errors"
 	"log/slog"
+	"strings"
 
 	ldap "github.com/netresearch/simple-ldap-go"
 )
@@ -25,8 +26,10 @@ func (h *Handler) resetPassword(params []string) ([]string, error) {
 	// Get token from store
 	token, err := h.tokenStore.Get(tokenString)
 	if err != nil {
-		// Safely log token prefix (handle tokens shorter than 8 chars)
-		prefix := tokenString[:min(8, len(tokenString))]
+		// Safely log token prefix (handle tokens shorter than 8 chars and
+		// user-supplied bytes: the byte slice may split a multi-byte rune,
+		// so strip any resulting invalid UTF-8 before logging)
+		prefix := strings.ToValidUTF8(tokenString[:min(8, len(tokenString))], "")
 		slog.Warn("password_reset_invalid_token", "token_prefix", prefix)
 		return nil, errors.New("invalid or expired token")
 	}

--- a/internal/rpchandler/reset_password.go
+++ b/internal/rpchandler/reset_password.go
@@ -26,10 +26,7 @@ func (h *Handler) resetPassword(params []string) ([]string, error) {
 	token, err := h.tokenStore.Get(tokenString)
 	if err != nil {
 		// Safely log token prefix (handle tokens shorter than 8 chars)
-		prefix := tokenString
-		if len(tokenString) > 8 {
-			prefix = tokenString[:8]
-		}
+		prefix := tokenString[:min(8, len(tokenString))]
 		slog.Warn("password_reset_invalid_token", "token_prefix", prefix)
 		return nil, errors.New("invalid or expired token")
 	}

--- a/internal/web/AGENTS.md
+++ b/internal/web/AGENTS.md
@@ -357,7 +357,7 @@ console.log(items[0].toUpperCase()); // ❌ may crash if empty array
 **Performance checklist**:
 
 - [ ] TypeScript compiled cleanly (`bun run js:build`; no minification step is configured today — if added, reference it here)
-- [ ] CSS optimized (cssnano via PostCSS)
+- [ ] CSS optimized (Lightning CSS via @tailwindcss/postcss)
 - [ ] No unused Tailwind classes (purged automatically)
 - [ ] No console.log in production code
 

--- a/internal/web/static/js/app.ts
+++ b/internal/web/static/js/app.ts
@@ -101,7 +101,7 @@ export const init = (opts: Opts) => {
     };
     const paintBorderOnly = (invalid: boolean) => {
       // Strip any inline text from previous full paints, keep border state.
-      while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
+      errorContainer.replaceChildren();
       setFieldInvalidStyle(inputContainer, input, invalid);
     };
 

--- a/internal/web/static/js/error-utils.ts
+++ b/internal/web/static/js/error-utils.ts
@@ -65,7 +65,7 @@ export function updateErrorSummary(
     list.className = "mt-2 ml-5 list-decimal space-y-1 text-sm text-error-dark dark:text-error-light";
     errorSummary.appendChild(list);
   }
-  while (list.firstChild) list.removeChild(list.firstChild);
+  list.replaceChildren();
 
   for (const fe of fieldErrors) {
     const li = document.createElement("li");
@@ -96,7 +96,7 @@ export function updateErrorSummary(
  * matches the inline field errors (icon + text).
  */
 export function setSubmitError(container: HTMLElement, message: string): void {
-  while (container.firstChild) container.removeChild(container.firstChild);
+  container.replaceChildren();
   if (message) container.appendChild(createErrorElement(message));
 }
 
@@ -125,9 +125,7 @@ export function setFieldErrors(
   errors: string[]
 ): void {
   // Clear existing errors using safe DOM method
-  while (errorContainer.firstChild) {
-    errorContainer.removeChild(errorContainer.firstChild);
-  }
+  errorContainer.replaceChildren();
 
   setFieldInvalidStyle(inputContainer, input, errors.length > 0);
 

--- a/internal/web/static/js/policy-ui.ts
+++ b/internal/web/static/js/policy-ui.ts
@@ -51,7 +51,7 @@ function makeCheckIcon(): SVGSVGElement {
  * state on each <li> based on the current input value.
  */
 export function renderPolicyList(list: HTMLElement, rules: PolicyRule[]): (value: string) => void {
-  while (list.firstChild) list.removeChild(list.firstChild);
+  list.replaceChildren();
 
   const items = rules.map((rule) => {
     const li = document.createElement("li");
@@ -92,7 +92,7 @@ export function renderPolicyList(list: HTMLElement, rules: PolicyRule[]): (value
       iconWrap.classList.toggle("text-gray-500", !met);
       iconWrap.classList.toggle("dark:text-gray-400", !met);
 
-      while (iconWrap.firstChild) iconWrap.removeChild(iconWrap.firstChild);
+      iconWrap.replaceChildren();
       iconWrap.appendChild(met ? makeCheckIcon() : makeDotIcon());
     }
   };

--- a/internal/web/static/js/reset-password.ts
+++ b/internal/web/static/js/reset-password.ts
@@ -104,7 +104,7 @@ export const init = (opts: Opts) => {
       setFieldErrors(errorContainer, inputContainer, input, errors);
     };
     const paintBorderOnly = (invalid: boolean) => {
-      while (errorContainer.firstChild) errorContainer.removeChild(errorContainer.firstChild);
+      errorContainer.replaceChildren();
       setFieldInvalidStyle(inputContainer, input, invalid);
     };
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -324,8 +326,16 @@ func run(args []string) int {
 		return 1
 	}
 
+	// Shut down gracefully on SIGINT/SIGTERM so in-flight requests (e.g.
+	// password resets) complete before the container stops.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	slog.Info("starting server", "port", opts.Port, "version", version, "build", build, "build_time", buildTime)
-	if err := app.Listen(":" + opts.Port); err != nil {
+	if err := app.Listen(":"+opts.Port, fiber.ListenConfig{
+		GracefulContext: ctx,
+		ShutdownTimeout: 10 * time.Second,
+	}); err != nil {
 		slog.Error("failed to start web server", "error", err)
 		return 1
 	}

--- a/main.go
+++ b/main.go
@@ -297,6 +297,17 @@ var (
 // the default value, which calls runHealthCheck.
 var healthCheckFunc = runHealthCheck
 
+// buildServerFunc and shutdownContextFunc are indirections used by run() so the
+// listen/graceful-shutdown path can be exercised without a real LDAP backend or
+// process signals. Production uses the defaults; tests override them (see the
+// healthCheckFunc pattern above).
+var (
+	buildServerFunc     = buildServer
+	shutdownContextFunc = func() (context.Context, context.CancelFunc) {
+		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
+)
+
 // run is the testable entry point. It returns an exit code so main() only
 // needs to call os.Exit. run never calls os.Exit itself.
 //
@@ -320,7 +331,7 @@ func run(args []string) int {
 		return 1
 	}
 
-	app, err := buildServer(opts)
+	app, err := buildServerFunc(opts)
 	if err != nil {
 		slog.Error("initialization failed", "error", err)
 		return 1
@@ -328,7 +339,7 @@ func run(args []string) int {
 
 	// Shut down gracefully on SIGINT/SIGTERM so in-flight requests (e.g.
 	// password resets) complete before the container stops.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := shutdownContextFunc()
 	defer stop()
 
 	slog.Info("starting server", "port", opts.Port, "version", version, "build", build, "build_time", buildTime)

--- a/main_test.go
+++ b/main_test.go
@@ -623,3 +623,54 @@ func BenchmarkRunHealthCheck(b *testing.B) {
 		_ = testableRunHealthCheck(server.URL + "/health/live")
 	}
 }
+
+// restoreRunSeams returns a cleanup closure restoring the buildServerFunc and
+// shutdownContextFunc indirections after a test overrides them.
+func restoreRunSeams(
+	bs func(*options.Opts) (*fiber.App, error),
+	sc func() (context.Context, context.CancelFunc),
+) func() {
+	return func() {
+		buildServerFunc = bs
+		shutdownContextFunc = sc
+	}
+}
+
+// TestRunGracefulShutdown drives run() through the successful listen path with
+// an already-canceled shutdown context, so fiber.Listen shuts down gracefully
+// and run() returns 0. buildServerFunc is stubbed to avoid a real LDAP backend
+// and shutdownContextFunc to avoid process signals.
+func TestRunGracefulShutdown(t *testing.T) {
+	t.Cleanup(restoreRunSeams(buildServerFunc, shutdownContextFunc))
+
+	// Minimal app with no LDAP dependency.
+	buildServerFunc = func(_ *options.Opts) (*fiber.App, error) {
+		return fiber.New(), nil
+	}
+	// Cancel shortly after listen starts so the graceful-shutdown watcher,
+	// which arms once the listener is bound, observes it and returns.
+	shutdownContextFunc = func() (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		return ctx, cancel
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		// Port 0 => an ephemeral free port, so the test never collides.
+		done <- run([]string{
+			"app",
+			"-ldap-server", "ldap://127.0.0.1:389",
+			"-base-dn", "dc=example,dc=com",
+			"-readonly-user", "cn=readonly,dc=example,dc=com",
+			"-readonly-password", "secret",
+			"-port", "0",
+		})
+	}()
+
+	select {
+	case code := <-done:
+		assert.Equal(t, 0, code, "run() must return 0 after a graceful shutdown")
+	case <-time.After(10 * time.Second):
+		t.Fatal("run() did not return after the shutdown context was canceled")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "tailwindcss": "^4.3.2",
     "typescript": "^7.0.0",
     "typescript-eslint": "^8.63.0"
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,13 +18,10 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/postcss": "^4.3.2",
-    "autoprefixer": "^10.5.2",
-    "cssnano": "^8.0.2",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
     "postcss": "^8.5.19",
     "postcss-cli": "^11.0.1",
-    "postcss-nested": "^7.0.2",
     "prettier": "^3.9.5",
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-tailwindcss": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.2",
-    "typescript": "^7.0.0",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0"
   },
   "overrides": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,5 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
-    "postcss-nested": {},
-    autoprefixer: {},
-    cssnano: {}
+    "@tailwindcss/postcss": { optimize: { minify: true } }
   }
 };

--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,11 @@
       "automerge": true
     },
     {
-      "description": "typescript-eslint peers cap at <6.1.0; lift once TS 7 is supported (typescript-eslint#12518)",
+      "description": "typescript-eslint 8.x peers cap at <6.1.0 (breaks bun run lint above it); lift when TS 7 is supported (typescript-eslint#12518)",
       "matchPackageNames": [
         "typescript"
       ],
-      "allowedVersions": "<7"
+      "allowedVersions": "<6.1.0"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,13 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "typescript-eslint peers cap at <6.1.0; lift once TS 7 is supported (typescript-eslint#12518)",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "allowedVersions": "<7"
     }
   ]
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-const config = {
-  content: ["internal/web/templates/*.html"],
-  darkMode: "selector"
-};
-
-export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Full upgrade pass: security/toolchain fixes, config modernization, and adoption of newer Go/TS/CSS features. Every commit is atomic and independently gated (`go test -race`, `golangci-lint`, `tsc`, `eslint`, prettier).

## Fixes

- **brace-expansion override → 5.0.7** — closes the only open `bun audit` advisory ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2), transitive via minimatch)
- **typescript pinned `~6.0.3`** — TS 7.0 removed the programmatic compiler API, so `bun run lint` has crashed since the `^7.0.0` bump (unnoticed: CI runs tsc only). typescript-eslint peers cap at `<6.1.0`; a renovate rule holds `<7` until [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518) lands
- **`.golangci.yml`: `gomodguard` → `gomodguard_v2`** (deprecated since golangci-lint v2.12)

## CSS/tooling modernization

- **Dead v3 `tailwind.config.js` removed** (never loaded — v4 requires `@config`); prettier now gets `tailwindStylesheet` so class sorting sees the custom variants
- **PostCSS chain reduced to `@tailwindcss/postcss`** with explicit `optimize.minify` — Lightning CSS covers what postcss-nested/autoprefixer/cssnano did (output A/B: identical flattening, gains `-webkit-backdrop-filter`, +387 bytes; 3 devDeps removed)
- **eslint config migrated to `defineConfig` + native `extends`** (typescript-eslint deprecated its `config()` wrapper)
- **tsconfig: `verbatimModuleSyntax` + `erasableSyntaxOnly`** — import hygiene moves into tsc, which CI actually runs

## Code upgrades

- **`Element.replaceChildren()`** replaces seven while-firstChild loops (Baseline, within the Chrome 90+ floor)
- **`slices.DeleteFunc`/`ContainsFunc` + `min()`** in the rate limiter and token-prefix logging
- **`testing/synctest`** for the 15 sliding-window/expiry/cleanup tests — fake clock, deterministic (`-race -count=3` verified)
- **Graceful shutdown**: `fiber.ListenConfig` with signal-bound `GracefulContext` + 10s `ShutdownTimeout`; verified by SIGTERM against a running instance (clean exit ~1s)

## Deferred

- Client-IP extraction → Fiber `TrustProxy` allowlist: [#621](https://github.com/netresearch/ldap-selfservice-password-changer/issues/621) (needs a deployment-topology decision; today any direct client can spoof X-Forwarded-For past the IP rate limiter)

## Not touched (deliberate)

Go deps are all current (fiber v3.4.0, simple-ldap-go v1.12.0, fasthttp v1.72.0); patch/minor npm bumps left to Renovate; GitHub Actions versions are owned by the go-app template (drift check); alpine:3.24.1 is newest. Rejected as harmful: `crypto/rand.Text()` (halves token entropy), fiber healthcheck middleware (breaks the baked-in `/health/live` path).