### PR TITLE
docs(compose): correct env_file vs environment precedence

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -108,8 +108,9 @@ services:
     container_name: gopherpass-app
     ports:
       - "${APP_PORT:-3000}:3000"
-    # Dev defaults — hermetic, point at the services above. Override anything
-    # via .env.local if needed (loaded after these defaults).
+    # Dev defaults — hermetic, point at the services above. These inline values
+    # take precedence over env_file, so .env.local can only supply variables
+    # that are NOT listed here; to change one of these, edit it below.
     environment:
       # LDAP — least-privilege accounts (reflects production wiring).
       LDAP_SERVER: "ldap://openldap:389"
@@ -140,8 +141,8 @@ services:
       SMTP_FROM_ADDRESS: "noreply@netresearch.local"
       APP_BASE_URL: "http://localhost:3000"
     env_file:
-      # Optional local override. Compose v2 treats missing files as empty
-      # when `required: false` is set.
+      # Optional fallback for variables absent from `environment:` above.
+      # Compose v2 treats missing files as empty when `required: false` is set.
       - path: .env.local
         required: false
     depends_on:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -739,9 +739,13 @@ The stack's password policy is ≥10 chars with 1 number, 1 symbol, 1 uppercase 
 ### Driving a Reset by Username
 
 This exercises `RESET_IDENTIFIER_MODE`. Set it to `both` via `.env.local` in the
-worktree (Compose loads `.env.local` _after_ the inline environment, so it wins)
-and recreate `app`. Then submit a **username** and confirm Mailpit received mail
-addressed to the account's **registered** address, not the typed identifier:
+worktree and recreate `app`. This works because `RESET_IDENTIFIER_MODE` is _not_
+in the `app` service's inline `environment:` block — Compose's `env_file` only
+supplies variables that block does not already define. A variable listed inline
+always wins over `.env.local`, so appending e.g. `SMTP_HOST` there has no effect;
+to change one of those, edit `compose.yml` instead. Then submit a **username** and
+confirm Mailpit received mail addressed to the account's **registered** address,
+not the typed identifier:
 
 ```bash
 printf 'RESET_IDENTIFIER_MODE=both\n' >> .env.local  # append — never clobber an existing .env.local


### PR DESCRIPTION
## Description

`docs/development-guide.md`, added in #630, states the precedence between Compose's `env_file` and a service's inline `environment:` block backwards:

> Compose loads `.env.local` _after_ the inline environment, so it wins

The opposite is true: a service's `environment:` block takes precedence, and `env_file` only supplies variables that block does not already define.

The instruction it supports still happens to work, but for a reason the text gets wrong. `RESET_IDENTIFIER_MODE` is not in the `app` service's inline block, so `.env.local` does supply it. An operator generalising from the stated rule — appending `SMTP_HOST` or any other inline-defined variable to `.env.local` — would watch the inline value win silently and have no way to explain it from the docs.

## Type of Change

- [x] 📝 Documentation update
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## Related Issues

Corrects documentation introduced in #630.

## Changes Made

Replaces the incorrect precedence claim with the actual rule, states why the `RESET_IDENTIFIER_MODE` instruction still works, and tells the reader what to do instead for a variable that *is* defined inline (edit `compose.yml`).

## Testing

### Test Cases

- [x] Documentation-only; no code paths change.
- [x] The corrected rule was verified by running it, on Docker Compose v5.3.1, using a minimal service with one key defined in both `environment:` and `env_file`, and one key defined only in `env_file`:

```
BOTH=from_inline   ONLY_FILE=from_envfile
```

The inline value wins where both define the key; `env_file` supplies only what the inline block omits. That is the rule this PR documents, and the inverse of what the text said.

## Deployment Notes

None. Documentation only.

---

https://claude.ai/code/session_015JAZYAZ9LgWdjrcU9sBFqM
