### PR TITLE
docs: correct AGENTS.md env vars, reserved test domains, and dev-stack runbook gaps

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -705,6 +705,34 @@ earlier run collides. Clear them and retry:
 docker rm -f gopherpass-openldap gopherpass-mailpit gopherpass-app
 ```
 
+**`APP_BASE_URL` must move with `APP_PORT`.** `compose.yml` pins
+`APP_BASE_URL: "http://localhost:3000"` in the `app` service's inline
+`environment:` block, and inline values win over `.env.local`. Change only
+`APP_PORT` and the app serves on `:3140` while every reset email it sends links
+to `:3000`, where nothing is listening — the mail arrives and the link is dead.
+Edit the `APP_BASE_URL` line in `compose.yml` to match the port you chose.
+
+### Exercising Custom Email Templates
+
+`EMAIL_TEMPLATE_HTML` and `EMAIL_TEMPLATE_TEXT` take paths that must resolve
+**inside the app container**. The runtime image is `FROM scratch` and the `app`
+service declares no `volumes:`, so a path that exists only on the host resolves
+to nothing and startup fails with `text template: stat …: no such file or
+directory`. Bind-mount the file and point the variable at the container path:
+
+```yaml
+# compose.yml, under the app service
+volumes:
+  - ./dev/reset.txt.tmpl:/config/email/reset.txt.tmpl:ro
+environment:
+  EMAIL_TEMPLATE_TEXT: /config/email/reset.txt.tmpl
+```
+
+Template fields are `{{.ResetLink}}`, `{{.Token}}`, `{{.BaseURL}}`,
+`{{.Recipient}}` and `{{.ExpiryMinutes}}`. Leaving one of the two body templates
+unset is fine — the unset side falls back to the template embedded in the binary,
+which is a useful way to compare a custom body against the default in one message.
+
 ### Route B: Native Binary Against Compose Infra
 
 Only if you don't want to rebuild the image. Note that Mailpit's SMTP port (1025)

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,6 +1,6 @@
 # Go Backend Services
 
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-04-18 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-07-22 -->
 
 **Scope**: Go backend packages in `internal/` directory
 
@@ -20,22 +20,29 @@ Backend services for LDAP selfservice password change/reset functionality. Organ
 
 ## Setup/Environment
 
-**Required environment variables** (configure in `.env.local`):
+**Environment variables** (configure in `.env.local`; names must match `options/app.go`):
 
 ```bash
-# LDAP connection
-LDAP_URL=ldaps://ldap.example.com:636
-LDAP_USER_BASE_DN=ou=users,dc=example,dc=com
-LDAP_BIND_DN=cn=admin,dc=example,dc=com
-LDAP_BIND_PASSWORD=secret
+# LDAP connection (the four below are the only *required* variables)
+LDAP_SERVER=ldaps://ldap.example.com:636
+LDAP_BASE_DN=dc=example,dc=com
+LDAP_READONLY_USER=cn=readonly,dc=example,dc=com
+LDAP_READONLY_PASSWORD=secret
+LDAP_IS_AD=false   # optional; true for ActiveDirectory (then LDAP_SERVER must be ldaps://)
+
+# Optional dedicated reset account (falls back to the readonly user)
+LDAP_RESET_USER=cn=password-reset,dc=example,dc=com
+LDAP_RESET_PASSWORD=secret
 
 # Email for password reset
+PASSWORD_RESET_ENABLED=true
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
-SMTP_USER=noreply@example.com
+SMTP_USERNAME=noreply@example.com
 SMTP_PASSWORD=secret
-SMTP_FROM=noreply@example.com
+SMTP_FROM_ADDRESS=noreply@example.com
 APP_BASE_URL=https://passwd.example.com
+RESET_IDENTIFIER_MODE=email   # optional; email (default), username, or both
 
 # Email templating (optional; unset => built-in defaults)
 SMTP_FROM_NAME=ACME IT
@@ -45,12 +52,23 @@ EMAIL_TEMPLATE_HTML=/config/email/reset.html
 EMAIL_TEMPLATE_TEXT=/config/email/reset.txt
 # Raw header escape hatch (suffix _ -> -): SMTP_HEADER_OVERRIDE_X_HELPDESK_TOPIC=...
 
-# Rate limiting (optional)
-RATE_LIMIT_REQUESTS=3
-RATE_LIMIT_WINDOW=1h
+# Rate limiting (optional; window is in minutes, not a duration string)
+RESET_RATE_LIMIT_REQUESTS=3
+RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
-# Token expiry (optional)
-TOKEN_EXPIRY_DURATION=1h
+# Token expiry (optional; minutes, not a duration string)
+RESET_TOKEN_EXPIRY_MINUTES=15
+
+# Password policy (optional; defaults shown)
+MIN_LENGTH=8
+MIN_NUMBERS=1
+MIN_SYMBOLS=1
+MIN_UPPERCASE=1
+MIN_LOWERCASE=1
+PASSWORD_CAN_INCLUDE_USERNAME=false
+
+# HTTP (optional)
+PORT=3000
 ```
 
 **Go toolchain**: Requires Go 1.26+ (specified in `go.mod`)
@@ -170,14 +188,14 @@ conn, _ := ldap.Dial(url)
 **Token Security**:
 
 - Cryptographic random tokens (see `resettoken/token.go`)
-- Configurable expiry (default 1h)
+- Configurable expiry via `RESET_TOKEN_EXPIRY_MINUTES` (default 15 minutes)
 - Single-use tokens (invalidated after use)
 - No token storage in logs or metrics
 
 **Rate Limiting**:
 
-- IP-based limits: 3 requests/hour default
-- Configurable via `RATE_LIMIT_*` env vars
+- IP-based limits: 3 requests per 60-minute window by default
+- Configurable via `RESET_RATE_LIMIT_REQUESTS` / `RESET_RATE_LIMIT_WINDOW_MINUTES`
 - In-memory store (consider Redis for multi-instance)
 - Apply to both change and reset endpoints
 
@@ -219,11 +237,13 @@ conn, _ := ldap.Dial(url)
 
 **✅ Good: Type-safe configuration**
 
+Pattern only — this project parses config with `flag` + `godotenv` in `options/app.go`, not with struct tags. The variable names below are the real ones.
+
 ```go
 type Config struct {
-    LDAPURL      string `env:"LDAP_URL" validate:"required,url"`
-    BindDN       string `env:"LDAP_BIND_DN" validate:"required"`
-    BindPassword string `env:"LDAP_BIND_PASSWORD" validate:"required"`
+    LDAPServer       string `env:"LDAP_SERVER" validate:"required,url"`
+    ReadonlyUser     string `env:"LDAP_READONLY_USER" validate:"required"`
+    ReadonlyPassword string `env:"LDAP_READONLY_PASSWORD" validate:"required"`
 }
 
 func LoadConfig() (*Config, error) {
@@ -240,7 +260,7 @@ func LoadConfig() (*Config, error) {
 ```go
 func LoadConfig() *Config {
     return &Config{
-        LDAPURL: os.Getenv("LDAP_URL"),  // ❌ no validation, may be empty
+        LDAPServer: os.Getenv("LDAP_SERVER"),  // ❌ no validation, may be empty
     }
 }
 ```
@@ -320,7 +340,7 @@ func ResetPassword(username string) error {
 1. **Module issues**: `go mod tidy` to clean dependencies
 2. **Import errors**: Check `go.mod` requires correct versions
 3. **Test failures**: `go test -v ./... -run FailingTest` for verbose output
-4. **LDAP connection**: Verify `LDAP_URL` format and network access
+4. **LDAP connection**: Verify `LDAP_SERVER` format and network access
 5. **Email testing**: Ensure Docker running for testcontainers (MailHog)
 6. **Rate limit testing**: Tests may fail if system time incorrect
 

--- a/internal/email/email_fuzz_test.go
+++ b/internal/email/email_fuzz_test.go
@@ -111,7 +111,7 @@ func FuzzHeaderOverrideValidation(f *testing.F) {
 		{"Naïve", "value"},
 		{"Subject", "operator subject"},
 		{"From", "attacker@evil.example"},
-		{"Reply-To", "helpdesk@acme.com"},
+		{"Reply-To", "helpdesk@example.com"},
 		{"mime-version", "9.9"},
 		{"Content-Type", "text/plain"},
 		{"X-Long", strings.Repeat("a", 2000)},
@@ -132,7 +132,7 @@ func FuzzHeaderOverrideValidation(f *testing.F) {
 		}
 
 		svc := newClockedService(&Config{
-			FromAddress:     "noreply@acme.com",
+			FromAddress:     "noreply@example.com",
 			HeaderOverrides: map[string]string{name: value},
 		})
 		msg, err := svc.buildMIMEMessage(

--- a/internal/email/headers_internal_test.go
+++ b/internal/email/headers_internal_test.go
@@ -46,20 +46,20 @@ func TestEncodeSubject(t *testing.T) {
 }
 
 func TestFormatFrom(t *testing.T) {
-	if got := formatFrom("", "noreply@acme.com"); got != "noreply@acme.com" {
-		t.Errorf("bare from = %q, want noreply@acme.com", got)
+	if got := formatFrom("", "noreply@example.com"); got != "noreply@example.com" {
+		t.Errorf("bare from = %q, want noreply@example.com", got)
 	}
-	if got := formatFrom("ACME IT", "noreply@acme.com"); got != `"ACME IT" <noreply@acme.com>` {
+	if got := formatFrom("ACME IT", "noreply@example.com"); got != `"ACME IT" <noreply@example.com>` {
 		t.Errorf("named from = %q", got)
 	}
 	// Plain ASCII display name with no specials: mail.Address.String() ALWAYS
 	// quotes an all-printable display name, so the quoted form is correct.
-	// Do NOT expect `ACME <noreply@acme.com>` — that assertion would fail.
-	if got := formatFrom("ACME", "noreply@acme.com"); got != `"ACME" <noreply@acme.com>` {
+	// Do NOT expect `ACME <noreply@example.com>` — that assertion would fail.
+	if got := formatFrom("ACME", "noreply@example.com"); got != `"ACME" <noreply@example.com>` {
 		t.Errorf("ascii name = %q, want quoted form", got)
 	}
 	// Non-ASCII display name must be RFC 2047 encoded.
-	if got := formatFrom("ACME Straße", "noreply@acme.com"); !strings.Contains(got, "=?utf-8?") &&
+	if got := formatFrom("ACME Straße", "noreply@example.com"); !strings.Contains(got, "=?utf-8?") &&
 		!strings.Contains(got, "=?UTF-8?") {
 		t.Errorf("non-ASCII name not encoded: %q", got)
 	}
@@ -92,9 +92,9 @@ func TestFormatFromEmptyAddressDropsName(t *testing.T) {
 // non-empty From value formatFrom produces must parse back as an address.
 func TestFormatFromAlwaysParseable(t *testing.T) {
 	cases := []struct{ name, address string }{
-		{"", "noreply@acme.com"},
-		{"ACME IT", "noreply@acme.com"},
-		{"ACME Straße", "noreply@acme.com"},
+		{"", "noreply@example.com"},
+		{"ACME IT", "noreply@example.com"},
+		{"ACME Straße", "noreply@example.com"},
 		{"ACME IT", ""},
 		{"", ""},
 	}
@@ -111,12 +111,12 @@ func TestFormatFromAlwaysParseable(t *testing.T) {
 
 func TestApplyHeaderOverrides(t *testing.T) {
 	base := []headerField{
-		{key: "From", value: "noreply@acme.com"},
-		{key: "To", value: "u@x.com"},
+		{key: "From", value: "noreply@example.com"},
+		{key: "To", value: "u@example.org"},
 	}
 	out := applyHeaderOverrides(base, map[string]string{
-		"from":             "ACME <help@acme.com>", // canonical-key match, replaces
-		"X-HelpDesk-Topic": "reset",                // new, appended
+		"from":             "ACME <help@example.com>", // canonical-key match, replaces
+		"X-HelpDesk-Topic": "reset",                   // new, appended
 	})
 
 	var from, topic string
@@ -133,7 +133,7 @@ func TestApplyHeaderOverrides(t *testing.T) {
 	if fromCount != 1 {
 		t.Errorf("From appears %d times, want 1", fromCount)
 	}
-	if from != "ACME <help@acme.com>" {
+	if from != "ACME <help@example.com>" {
 		t.Errorf("From = %q, want override value", from)
 	}
 	if topic != "reset" {

--- a/internal/email/message_internal_test.go
+++ b/internal/email/message_internal_test.go
@@ -64,8 +64,8 @@ func parseMessage(t *testing.T, raw []byte) (textproto.MIMEHeader, *multipart.Re
 // rejects such values at startup, but the email package must not depend on it.
 func TestBuildMIMEMessage_RejectsInjectedOverride(t *testing.T) {
 	cases := map[string]map[string]string{
-		"crlf in value":    {"X-Evil": "ok\r\nBcc: attacker@evil.com"},
-		"lone lf in value": {"X-Evil": "ok\nBcc: attacker@evil.com"},
+		"crlf in value":    {"X-Evil": "ok\r\nBcc: attacker@evil.invalid"},
+		"lone lf in value": {"X-Evil": "ok\nBcc: attacker@evil.invalid"},
 		"nul in value":     {"X-Evil": "a\x00b"},
 		"space in name":    {"X Bad": "value"},
 		"colon in name":    {"X:Bad": "value"},
@@ -73,8 +73,8 @@ func TestBuildMIMEMessage_RejectsInjectedOverride(t *testing.T) {
 
 	for name, overrides := range cases {
 		t.Run(name, func(t *testing.T) {
-			s := newClockedService(&Config{FromAddress: "noreply@acme.com", HeaderOverrides: overrides})
-			raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+			s := newClockedService(&Config{FromAddress: "noreply@example.com", HeaderOverrides: overrides})
+			raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 			if err == nil {
 				t.Fatalf("expected an error; got a message:\n%s", raw)
 			}
@@ -90,10 +90,10 @@ func TestBuildMIMEMessage_RejectsInjectedOverride(t *testing.T) {
 // rather than emitted a second time, which would corrupt the multipart parse.
 func TestBuildMIMEMessage_DropsReservedOverride(t *testing.T) {
 	s := newClockedService(&Config{
-		FromAddress:     "noreply@acme.com",
+		FromAddress:     "noreply@example.com",
 		HeaderOverrides: map[string]string{"Content-Type": "text/plain", "Mime-Version": "9.9"},
 	})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
@@ -112,8 +112,8 @@ func TestBuildMIMEMessage_DropsReservedOverride(t *testing.T) {
 // textproto.ReadMIMEHeader tolerates bare LF, so parsing alone cannot catch a
 // regression here.
 func TestBuildMIMEMessage_LineEndings(t *testing.T) {
-	s := newClockedService(&Config{FromAddress: "noreply@acme.com"})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	s := newClockedService(&Config{FromAddress: "noreply@example.com"})
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
@@ -133,17 +133,18 @@ func TestBuildMIMEMessage_LineEndings(t *testing.T) {
 }
 
 func TestBuildMIMEMessage_Structure(t *testing.T) {
-	s := newClockedService(&Config{FromAddress: "noreply@acme.com"})
-	raw, err := s.buildMIMEMessage("user@x.com", "Password Reset Request", "TEXT BODY link=x", "<p>HTML BODY link=x</p>")
+	s := newClockedService(&Config{FromAddress: "noreply@example.com"})
+	raw, err := s.buildMIMEMessage(
+		"user@example.org", "Password Reset Request", "TEXT BODY link=x", "<p>HTML BODY link=x</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
 
 	hdr, mr := parseMessage(t, raw)
-	if hdr.Get("From") != "noreply@acme.com" {
+	if hdr.Get("From") != "noreply@example.com" {
 		t.Errorf("From = %q", hdr.Get("From"))
 	}
-	if hdr.Get("To") != "user@x.com" {
+	if hdr.Get("To") != "user@example.org" {
 		t.Errorf("To = %q", hdr.Get("To"))
 	}
 	if hdr.Get("Subject") != "Password Reset Request" {
@@ -188,32 +189,32 @@ func TestBuildMIMEMessage_Structure(t *testing.T) {
 }
 
 func TestBuildMIMEMessage_FromNameAndReplyTo(t *testing.T) {
-	s := newClockedService(&Config{FromAddress: "noreply@acme.com", FromName: "ACME IT", ReplyTo: "help@acme.com"})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	s := newClockedService(&Config{FromAddress: "noreply@example.com", FromName: "ACME IT", ReplyTo: "help@example.com"})
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
 	hdr, _ := parseMessage(t, raw)
-	if hdr.Get("From") != `"ACME IT" <noreply@acme.com>` {
+	if hdr.Get("From") != `"ACME IT" <noreply@example.com>` {
 		t.Errorf("From = %q", hdr.Get("From"))
 	}
-	if hdr.Get("Reply-To") != "help@acme.com" {
+	if hdr.Get("Reply-To") != "help@example.com" {
 		t.Errorf("Reply-To = %q", hdr.Get("Reply-To"))
 	}
 }
 
 func TestBuildMIMEMessage_OverridePrecedence(t *testing.T) {
 	s := newClockedService(&Config{
-		FromAddress:     "noreply@acme.com",
+		FromAddress:     "noreply@example.com",
 		FromName:        "ACME IT",
-		HeaderOverrides: map[string]string{"From": "Custom <c@acme.com>", "X-HelpDesk-Topic": "reset"},
+		HeaderOverrides: map[string]string{"From": "Custom <c@example.com>", "X-HelpDesk-Topic": "reset"},
 	})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
 	hdr, _ := parseMessage(t, raw)
-	if hdr.Get("From") != "Custom <c@acme.com>" {
+	if hdr.Get("From") != "Custom <c@example.com>" {
 		t.Errorf("From override not applied: %q", hdr.Get("From"))
 	}
 	if hdr.Get("X-Helpdesk-Topic") != "reset" {
@@ -223,16 +224,16 @@ func TestBuildMIMEMessage_OverridePrecedence(t *testing.T) {
 
 func TestBuildMIMEMessage_OverrideReplacesReplyTo(t *testing.T) {
 	s := newClockedService(&Config{
-		FromAddress:     "noreply@acme.com",
-		ReplyTo:         "help@acme.com",
-		HeaderOverrides: map[string]string{"Reply-To": "other@acme.com"},
+		FromAddress:     "noreply@example.com",
+		ReplyTo:         "help@example.com",
+		HeaderOverrides: map[string]string{"Reply-To": "other@example.com"},
 	})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
 	hdr, _ := parseMessage(t, raw)
-	if got := hdr.Get("Reply-To"); got != "other@acme.com" {
+	if got := hdr.Get("Reply-To"); got != "other@example.com" {
 		t.Errorf("Reply-To = %q, want override value", got)
 	}
 	if got := hdr["Reply-To"]; len(got) != 1 {
@@ -244,8 +245,8 @@ func TestBuildMIMEMessage_OverrideReplacesReplyTo(t *testing.T) {
 // requirement: exactly one Date field, carrying the service clock's instant in
 // a form net/mail can parse back, numeric zone offset included.
 func TestBuildMIMEMessage_DateHeader(t *testing.T) {
-	s := newClockedService(&Config{FromAddress: "noreply@acme.com"})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	s := newClockedService(&Config{FromAddress: "noreply@example.com"})
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}
@@ -285,10 +286,10 @@ func TestBuildMIMEMessage_DateHeader(t *testing.T) {
 func TestBuildMIMEMessage_OverrideReplacesDate(t *testing.T) {
 	const override = "Tue, 01 Jan 2030 00:00:00 +0000"
 	s := newClockedService(&Config{
-		FromAddress:     "noreply@acme.com",
+		FromAddress:     "noreply@example.com",
 		HeaderOverrides: map[string]string{"Date": override},
 	})
-	raw, err := s.buildMIMEMessage("user@x.com", "Sub", "t", "<p>h</p>")
+	raw, err := s.buildMIMEMessage("user@example.org", "Sub", "t", "<p>h</p>")
 	if err != nil {
 		t.Fatalf("buildMIMEMessage: %v", err)
 	}

--- a/internal/email/render_internal_test.go
+++ b/internal/email/render_internal_test.go
@@ -104,14 +104,14 @@ func TestNewRenderer_CustomSubjectAndFiles(t *testing.T) {
 		t.Fatalf("newRenderer: %v", err)
 	}
 
-	subject, text, _, err := r.render(resetEmailData{Recipient: "u@x.com", ResetLink: "https://x/y"})
+	subject, text, _, err := r.render(resetEmailData{Recipient: "u@example.org", ResetLink: "https://x/y"})
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
 	if subject != "[ACME] Reset your password" {
 		t.Errorf("subject = %q", subject)
 	}
-	if !strings.Contains(text, "Reset for u@x.com: https://x/y") {
+	if !strings.Contains(text, "Reset for u@example.org: https://x/y") {
 		t.Errorf("text = %q", text)
 	}
 }


### PR DESCRIPTION
## Description

Clears the findings that were disclosed in #629 rather than fixed, plus two runbook gaps found by actually running the merged feature against the dev stack.

## Type of Change

- [x] 📝 Documentation update
- [x] ✅ Test coverage improvement
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## Changes Made

**`internal/AGENTS.md` documented variables the code does not read.** Eight names were wrong — `LDAP_BIND_DN` for `LDAP_READONLY_USER`, `SMTP_USER` for `SMTP_USERNAME`, `SMTP_FROM` for `SMTP_FROM_ADDRESS`, `RATE_LIMIT_*` for `RESET_RATE_LIMIT_*`, and two duration-style names for settings that are actually integer minutes. An agent configuring the app from that file produced a deployment that would not start. Every name is now re-derived from `internal/options/app.go`.

**Test fixtures used real registered domains.** RFC 2606 reserves `example.com` and the `.invalid` TLD so test data cannot point at somebody's property; the email tests used `acme.com` (~34 occurrences), `x.com`, and `evil.com`. Renamed to `example.com` / `example.org` / `evil.invalid`. Pure literal substitution — the only other changed lines are two gofmt realignments caused by the literals changing width. No assertion was altered.

**Two runbook gaps that make its own recipe fail.** Both were found by driving the email-template feature end to end against the documented dev stack:

- `APP_BASE_URL` is pinned inline in `compose.yml` to `http://localhost:3000`, and inline values win over `.env.local`. Following the runbook's `APP_PORT=3140` example serves the app on 3140 while every reset email links to 3000 — the mail arrives and the link is dead.
- `EMAIL_TEMPLATE_HTML`/`TEXT` take paths resolved *inside* the container, but the runtime image is `FROM scratch` and the `app` service declares no `volumes:`. A host-only path cannot resolve, and startup fails. Nothing documented how to get a template file in; the bind-mount recipe is now written down.

## Testing

### Test Cases

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l internal/ main.go` (clean)
- [x] `go test -count=1 ./internal/email/` passes after the rename
- [x] The rename was verified non-weakening: the header-injection rejection test and the override-precedence test were re-run against deliberately broken implementations and still fail
- [ ] Manual testing — not applicable to this PR's changes; the runbook corrections themselves came *from* a manual end-to-end run of #629

## Deployment Notes

None. Documentation and test fixtures only; no runtime code changes.

---

https://claude.ai/code/session_015JAZYAZ9LgWdjrcU9sBFqM
