### PR TITLE
docs: reconcile contradictions left by four concurrently-merged PRs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,53 +2,48 @@
 #
 # The stack ships sensible dev defaults in compose.yml — OpenLDAP (seeded
 # users) + Mailpit (SMTP sink at http://localhost:8025). You usually don't
-# need a .env.local at all. This file is loaded AFTER the defaults, so any
-# value you uncomment wins.
+# need a .env.local at all.
+#
+# HOW COMPOSE READS THIS FILE — check this before you uncomment anything.
+# The `app` service pins most settings inline in its `environment:` block, and
+# inline values WIN over `env_file:`. So .env.local can only supply variables
+# that block does not already name; uncommenting one it does name changes
+# nothing. 23 of the 30 commented entries below are inert for that reason, so
+# rather than tag each one the file is split into three parts:
+#
+#   PART 1 — takes effect from this file
+#   PART 2 — inert from this file; edit the value in compose.yml instead
+#   PART 3 — read by Compose itself, never through `env_file:`
+#
+# The split describes the compose dev stack only. A natively run binary loads
+# `.env.local` and then `.env` on its own (godotenv, internal/options/app.go),
+# so there the PART 1 and PART 2 variables apply directly. PART 3 is a Compose
+# concern and has no meaning for a native run (that binary takes `PORT`).
 
-# --- Point at a different LDAP server ----------------------------------
-# LDAP_SERVER=ldaps://ldap.example.com:636
-# LDAP_IS_AD=true
-# LDAP_BASE_DN=DC=example,DC=com
-# LDAP_READONLY_USER=cn=readonly,dc=example,dc=com
-# LDAP_READONLY_PASSWORD=readonly_password
+# =======================================================================
+# PART 1 — takes effect from .env.local
+# =======================================================================
+# None of these appear in the app service's inline `environment:` block, so
+# `env_file:` supplies them. Recreate the container after editing:
+#   docker compose --profile dev up -d --force-recreate app
 
-# --- Dedicated reset account (recommended for prod) --------------------
-# LDAP_RESET_USER=cn=password-reset,dc=example,dc=com
-# LDAP_RESET_PASSWORD=reset_password
-
-# --- Password policy ---------------------------------------------------
-# MIN_LENGTH=10
-# MIN_NUMBERS=1
-# MIN_SYMBOLS=1
-# MIN_UPPERCASE=1
-# MIN_LOWERCASE=1
-# PASSWORD_CAN_INCLUDE_USERNAME=false
-
-# --- Reset feature -----------------------------------------------------
-# PASSWORD_RESET_ENABLED=true
+# --- Reset identifier --------------------------------------------------
 # Which identifier the reset form accepts: email (default), username, or both.
 # Use `username` or `both` when several accounts share one email address
 # (Active Directory does not enforce a unique mail attribute). The reset link
 # is always sent to the account's registered email address, never to the typed
 # value.
 # RESET_IDENTIFIER_MODE=email
-# RESET_TOKEN_EXPIRY_MINUTES=15
-# RESET_RATE_LIMIT_REQUESTS=3
-# RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
-# --- SMTP (Mailpit by default — override for real SMTP) ----------------
-# SMTP_HOST=smtp.example.com
-# SMTP_PORT=587
-# SMTP_USERNAME=
-# SMTP_PASSWORD=
-# SMTP_FROM_ADDRESS=noreply@example.com
-# APP_BASE_URL=http://localhost:3000
-
-# --- Email templates & headers (optional) ------------------------------
+# --- Email templates & headers -----------------------------------------
 # Customize the reset email. Unset => built-in defaults.
 # SMTP_FROM_NAME=ACME IT
 # EMAIL_REPLY_TO=helpdesk@example.com
 # EMAIL_TEMPLATE_SUBJECT=[ACME] Reset your password
+# Template paths must resolve INSIDE the app container. The runtime image is
+# `FROM scratch` and the app service declares no `volumes:`, so a path that
+# exists only on the host fails startup — add the bind mount in compose.yml
+# first (see docs/development-guide.md).
 # EMAIL_TEMPLATE_HTML=/config/email/reset.html   # Go template, {{.ResetLink}} etc.
 # EMAIL_TEMPLATE_TEXT=/config/email/reset.txt
 # Raw header injection for routing/helpdesk integrations. One var per header;
@@ -71,6 +66,61 @@
 #
 # Template fields: {{.ResetLink}} {{.Token}} {{.BaseURL}} {{.Recipient}} {{.ExpiryMinutes}}
 
-# --- Port mapping overrides -------------------------------------------
-# APP_PORT=3000
-# MAILPIT_WEB_PORT=8025
+# =======================================================================
+# PART 2 — INERT from .env.local; edit compose.yml instead
+# =======================================================================
+# Every variable below is pinned in the app service's inline `environment:`
+# block (compose.yml), which beats `env_file:`. Uncommenting one here has no
+# effect on the compose stack — change the value on its line in compose.yml.
+# They are kept as a reference of the names and formats, and they do apply to
+# a natively run binary.
+
+# --- Point at a different LDAP server ----------------------------------
+# LDAP_SERVER=ldaps://ldap.example.com:636
+# LDAP_IS_AD=true
+# LDAP_BASE_DN=DC=example,DC=com
+# LDAP_READONLY_USER=cn=readonly,dc=example,dc=com
+# LDAP_READONLY_PASSWORD=readonly_password
+
+# --- Dedicated reset account (recommended for prod) --------------------
+# LDAP_RESET_USER=cn=password-reset,dc=example,dc=com
+# LDAP_RESET_PASSWORD=reset_password
+
+# --- Password policy ---------------------------------------------------
+# MIN_LENGTH=10
+# MIN_NUMBERS=1
+# MIN_SYMBOLS=1
+# MIN_UPPERCASE=1
+# MIN_LOWERCASE=1
+# PASSWORD_CAN_INCLUDE_USERNAME=false
+
+# --- Reset feature -----------------------------------------------------
+# PASSWORD_RESET_ENABLED=true
+# RESET_TOKEN_EXPIRY_MINUTES=15
+# RESET_RATE_LIMIT_REQUESTS=3
+# RESET_RATE_LIMIT_WINDOW_MINUTES=60
+
+# --- SMTP (Mailpit by default — override for real SMTP) ----------------
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM_ADDRESS=noreply@example.com
+# APP_BASE_URL=http://localhost:3000   # must match APP_PORT — see PART 3
+
+# =======================================================================
+# PART 3 — Compose interpolation; NOT read through `env_file:`
+# =======================================================================
+# These are not application settings. compose.yml substitutes them into
+# `ports:` (`"${APP_PORT:-3000}:3000"`, `"${MAILPIT_WEB_PORT:-8025}:8025"`),
+# and Compose takes substitution values from the shell environment or from the
+# `.env` file beside compose.yml — never from an `env_file:` entry. Putting
+# them here only injects two unused variables into the container.
+#
+#   APP_PORT=3140 MAILPIT_WEB_PORT=8125 docker compose --profile dev up -d
+#
+# APP_BASE_URL must move with APP_PORT. It is pinned inline (PART 2) at
+# http://localhost:3000, so moving only APP_PORT serves the app on the new
+# port while every reset email still links to :3000, where nothing is
+# listening — the mail arrives and the link is dead. Edit the APP_BASE_URL
+# line in compose.yml to match the port you chose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,10 @@ Source: `package.json` scripts + `go test`. Run from repo root.
 - **No secrets in git.** Use `.env.local` (gitignored). Never commit LDAP/SMTP credentials.
 - **LDAPS required** in production (`ldaps://` URLs).
 - **No PII logging** — passwords, tokens, session IDs never reach logs.
-- **Rate limiting** 3 req/hour/IP (configurable via `RATE_LIMIT_*`).
+- **Rate limiting** — two separate in-memory limiters, don't conflate them:
+  - **Per-IP**: 10 requests / 60 minutes, max 1000 tracked IPs. **Hardcoded** in `internal/ratelimit/ip_limiter.go` (`NewLimiterWithCapacity(10, 60*time.Minute, 1000)`); no environment variable configures it. Applies to `change-password` and `request-password-reset`.
+  - **Per-identifier (reset only)**: `RESET_RATE_LIMIT_REQUESTS` (default 3) per `RESET_RATE_LIMIT_WINDOW_MINUTES` (default 60), keyed by the typed identifier and again by the resolved account — not by IP.
+  - There is no `RATE_LIMIT_*` variable prefix.
 - **Cryptographic random tokens** with configurable expiry; single-use, server-side.
 - **Strict input validation** at boundaries — see `internal/validators/`.
 - **Container runs as UID 65534** (nobody), not root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,11 +261,14 @@ const form = document.querySelector("#form");
 
 ### Test Coverage Goals
 
-- **Validators**: 100% (maintain)
-- **RateLimit**: 70%+ (current: 72.3%)
-- **ResetToken**: 70%+ (current: 71.7%)
-- **RPC**: 50%+ (current: 45.6%)
-- **Email**: 30%+ (current: 31.2%)
+The coverage gate is enforced by Codecov; its project and patch targets live in
+the repository's Codecov configuration, which is the authority for the numbers.
+Current per-package coverage is on the
+[Codecov dashboard](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer),
+and `go test -cover ./...` prints it locally.
+
+Per-package percentages are deliberately not restated here. They used to be, and
+every one of them had drifted from reality by the time anyone read them.
 
 ### Running Tests
 
@@ -310,14 +313,18 @@ func TestValidateMinLength(t *testing.T) {
 }
 ```
 
-**Integration Tests** (use testcontainers):
+**Integration Tests** — guarded by the `integration` build tag and driven by
+environment variables pointing at real services. There is no testcontainers
+dependency; the services come from `docker compose --profile test up`, and
+`make test-integration` runs `go test -v -race -tags=integration ./...`. A test
+whose variables are unset skips rather than fails.
 
 ```go
-func TestPasswordReset_Integration(t *testing.T) {
-    // Start LDAP container
-    ctx := context.Background()
-    ldapContainer, err := openldap.Run(ctx, "bitnami/openldap:latest")
-    // ... test with real LDAP server
+//go:build integration
+
+func TestIntegration_NewHandler(t *testing.T) {
+    ldapServer := getEnvOrSkip(t, "LDAP_SERVER")
+    // ... test against that server
 }
 ```
 

--- a/PROJECT-INDEX.md
+++ b/PROJECT-INDEX.md
@@ -216,7 +216,7 @@ go test ./... -cover
 ### Security Features
 
 - **LDAPS Support**: Encrypted LDAP connections
-- **Rate Limiting**: 3 requests/hour per IP for reset requests
+- **Rate Limiting**: 10 requests/hour per IP (hardcoded) on both endpoints, plus 3 requests/hour per identifier for reset requests (configurable)
 - **Cryptographic Tokens**: 256-bit secure token generation
 - **No Password Storage**: Passwords never persisted
 - **Input Validation**: Client and server-side validation

--- a/PROJECT-INDEX.md
+++ b/PROJECT-INDEX.md
@@ -59,33 +59,15 @@
 | [ADR-0002](docs/adr/0002-password-reset-functionality.md)       | Password Reset Functionality       | ✅ Accepted | 2024-10-07 |
 | [ADR-0003](docs/adr/0003-configurable-reset-email-templates.md) | Configurable Reset Email Templates | ✅ Accepted | 2026-07-22 |
 
-### Analysis & Planning (`claudedocs/`)
+### Supplementary Documentation (`docs/`)
 
-**Project Context**
-
-- [Project Context Snapshot](claudedocs/project-context-2025-10-04.md)
-- [Component Reference](claudedocs/component-reference.md)
-- [Architecture Patterns](claudedocs/architecture-patterns.md)
-
-**Feature Implementation**
-
-- [Password Reset PRD](claudedocs/password-reset-prd.md)
-- [Implementation Workflow](claudedocs/password-reset-implementation-workflow.md)
-- [Phase 1 Complete](claudedocs/phase1-implementation-complete.md)
-
-**Quality & Validation**
-
-- [Validation Report](claudedocs/VALIDATION-REPORT.md)
-- [WCAG 2.2 Analysis](claudedocs/wcag-2.2-analysis-2025-10-07.md)
-- [WCAG Contrast Analysis](claudedocs/wcag-contrast-analysis.md)
-- [Accessibility Redesign Plan](claudedocs/accessibility-redesign-plan.md)
-
-**Testing & Guides**
-
-- [Testing Guide](claudedocs/testing-guide.md)
-- [Density Toggle Testing](claudedocs/density-toggle-testing-guide.md)
-- [Maintenance Guide](claudedocs/MAINTENANCE.md)
-- [Onboarding Checklist](claudedocs/onboarding-checklist.md)
+| Document                                                                        | Purpose                                        | Audience         |
+| ------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------- |
+| [Onboarding Checklist](docs/onboarding.md)                                      | Progressive learning path for new developers   | New developers   |
+| [Documentation Maintenance Guide](docs/maintenance.md)                          | Keeping documentation accurate as code evolves | Maintainers      |
+| [Security Assessment](docs/security-assessment-2025-10-09.md)                   | Security assessment report (2025-10-09)        | Security, DevOps |
+| [Security Assessment (Revised)](docs/security-assessment-revised-2025-10-09.md) | Revised security assessment report             | Security, DevOps |
+| [Security Quick Fix Guide](docs/security-quick-fix-guide.md)                    | Immediate actions for critical findings        | Developers       |
 
 ---
 
@@ -109,14 +91,14 @@ LDAP Selfservice Password Changer provides:
 
 ### Technology Stack
 
-| Layer         | Technology     | Version |
-| ------------- | -------------- | ------- |
-| Backend       | Go             | 1.26+   |
-| Web Framework | Fiber          | v2.52+  |
-| Frontend      | TypeScript     | 5.9+    |
-| CSS           | Tailwind CSS   | v4.1+   |
-| Build         | Bun            | latest  |
-| Testing       | testcontainers | Latest  |
+| Layer         | Technology   | Version                                |
+| ------------- | ------------ | -------------------------------------- |
+| Backend       | Go           | 1.26 (`go.mod`)                        |
+| Web Framework | Fiber        | v3.4.0 (`github.com/gofiber/fiber/v3`) |
+| Frontend      | TypeScript   | ~6.0.3 (`package.json`)                |
+| CSS           | Tailwind CSS | ^4.3.2 (`package.json`)                |
+| Build         | Bun          | no version pinned                      |
+| Testing       | testify      | v1.11.1 (`go.mod`)                     |
 
 ---
 
@@ -129,7 +111,7 @@ ldap-selfservice-password-changer/
 │   ├── options/           # Application configuration
 │   ├── ratelimit/         # Rate limiting middleware
 │   ├── resettoken/        # Token generation and storage
-│   ├── rpc/               # JSON-RPC handlers
+│   ├── rpchandler/        # JSON-RPC handlers
 │   ├── validators/        # Password validation rules
 │   └── web/               # Web server and static assets
 │       ├── static/        # Compiled JS, CSS, icons
@@ -139,7 +121,6 @@ ldap-selfservice-password-changer/
 │           └── molecules/ # Composite components
 ├── docs/                  # Official documentation
 │   └── adr/               # Architecture Decision Records
-├── claudedocs/            # Analysis and planning documents
 ├── main.go                # Application entry point
 ├── go.mod                 # Go dependencies
 ├── package.json           # Node.js dependencies
@@ -199,13 +180,10 @@ go build -o ldap-selfservice-password-changer
 go test ./... -cover
 ```
 
-**Current coverage**:
-
-- ✅ validators: 100.0%
-- ✅ ratelimit: 72.3%
-- ✅ resettoken: 71.7%
-- ✅ rpc: 45.6%
-- ✅ email: 31.2%
+**Current coverage**: tracked by Codecov, not restated here — see the
+[codecov badge and dashboard](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer).
+Hardcoded per-package percentages in Markdown go stale within a release; the
+command above prints the authoritative local numbers.
 
 **See [Testing Guide](docs/testing-guide.md) for comprehensive testing documentation.**
 
@@ -220,7 +198,9 @@ go test ./... -cover
 - **Cryptographic Tokens**: 256-bit secure token generation
 - **No Password Storage**: Passwords never persisted
 - **Input Validation**: Client and server-side validation
-- **CSRF Protection**: Token-based CSRF prevention
+
+There is no CSRF protection; see WAF-02 in
+[docs/security-assessment-revised-2025-10-09.md](docs/security-assessment-revised-2025-10-09.md).
 
 **See [Security Documentation](docs/security.md) for threat model and security architecture.**
 
@@ -263,7 +243,7 @@ See [README.md](README.md) for contributing guidelines.
 
 ## 📝 Document Maintenance
 
-**Last Updated**: 2025-10-08
+**Last Updated**: 2026-07-23
 **Maintained By**: Development Team
 **Update Frequency**: Per release + major changes
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Self-service password **change & reset** for **Active Directory and LDAP** — w
 
   <img src="./internal/web/static/logo.webp" height="256" alt="GopherPass Logo">
 
-[![Check](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check.yml)
+[![CI](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/codeql.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/codeql.yml)
+[![Template Drift](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml)
 [![codecov](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer/branch/main/graph/badge.svg)](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer)
 [![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ldap-selfservice-password-changer)](https://goreportcard.com/report/github.com/netresearch/ldap-selfservice-password-changer)
-[![Docker](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/docker.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/docker.yml)
+[![managed by netresearch/.github templates](https://img.shields.io/badge/template-netresearch%2F.github-2F99A4?logo=github)](https://github.com/netresearch/.github/tree/main/templates/go-app)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![WCAG 2.2 AAA](https://img.shields.io/badge/WCAG%202.2-AAA%20Compliant-brightgreen?style=flat-square)](https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize&levels=aaa)
 
@@ -61,9 +62,6 @@ Access at `http://localhost:3000`
 
 ```bash
 # Clone and build
-
-[![Template Drift](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml)
-[![managed by netresearch/.github templates](https://img.shields.io/badge/template-netresearch%2F.github-2F99A4?logo=github)](https://github.com/netresearch/.github/tree/main/templates/go-app)
 git clone https://github.com/netresearch/ldap-selfservice-password-changer
 cd ldap-selfservice-password-changer
 bun install

--- a/compose.yml
+++ b/compose.yml
@@ -130,7 +130,8 @@ services:
       # Reset feature
       PASSWORD_RESET_ENABLED: "true"
       RESET_TOKEN_EXPIRY_MINUTES: "15"
-      # Matches the default documented in AGENTS.md (3/hour/IP).
+      # Reset limiter only: 3/hour per typed identifier and per resolved
+      # account. The per-IP limiter (10/hour) is hardcoded and unaffected.
       RESET_RATE_LIMIT_REQUESTS: "3"
       RESET_RATE_LIMIT_WINDOW_MINUTES: "60"
       # SMTP → mailpit

--- a/docs/adr/0003-configurable-reset-email-templates.md
+++ b/docs/adr/0003-configurable-reset-email-templates.md
@@ -53,7 +53,9 @@ A single global `GOPHERPASS_*` prefix for every variable in the application was 
 
 Header configuration is split into two layers with different ownership of correctness:
 
-**Structured and validated** — `SMTP_FROM_NAME`, `EMAIL_REPLY_TO`. The application owns correctness: the display name is quoted or RFC 2047 encoded-word encoded as needed via `net/mail`, and the reply address is checked with `ValidateEmailAddress`.
+**Structured and validated** — `SMTP_FROM_NAME`, `EMAIL_REPLY_TO`. The application owns correctness: the display name is quoted or RFC 2047 encoded-word encoded as needed via `net/mail`, and the reply address is checked with `ValidateConfiguredAddress`.
+
+`ValidateConfiguredAddress` is `mail.ParseAddress`, deliberately more permissive than the recipient-side `ValidateEmailAddress` regex. That regex demands a dotted TLD, which rejects `noreply@localhost`, `gopherpass@intranet` and IP-literal domains — senders a containerised app relaying through a local MTA uses routinely, and which booted on every previous release. Recipient addresses keep the strict regex: they derive from directory data rather than operator config, so narrowing what is accepted there limits attack surface instead of breaking a working deployment.
 
 **Raw verbatim escape hatch** — `SMTP_HEADER_OVERRIDE_<NAME>=value`, env-only, built by scanning `os.Environ()` during `ParseArgs`, with `_` in the suffix mapped to `-` in the field name. The value is used exactly as given, with no encoding or quoting. The operator owns correctness; the application enforces only structural integrity.
 
@@ -63,7 +65,7 @@ The escape hatch exists because routing headers are open-ended. A structured API
 
 `MIME-Version`, `Content-Type` and `Content-Transfer-Encoding` cannot be set through `SMTP_HEADER_OVERRIDE_*`.
 
-The message builder owns these and appends them **after** overrides are applied. Permitting an override would emit a second, conflicting copy and corrupt the multipart structure — a message whose declared boundary no longer matches the body it wraps.
+The message builder owns these: `MIME-Version` and `Content-Type` are appended **after** overrides are applied, and `Content-Transfer-Encoding` is written per MIME part. Permitting an override would emit a second, conflicting copy and corrupt the multipart structure — a message whose declared boundary no longer matches the body it wraps.
 
 This is enforced in **both** layers, by design:
 
@@ -78,7 +80,7 @@ Without this, a header value is a header injection vector: a raw CR or LF lets a
 
 This validation lives in the `internal/email` package and runs over the **override map** in the message builder, not only at config-parse time. Overrides reach the builder from more than one direction, so the package that writes the wire format re-checks the values it was handed rather than trusting the options layer.
 
-The builder's own `From:`, `To:` and `Reply-To:` fields do not pass through `ValidateHeaderValue`. They are constrained where they are produced instead: `EMAIL_REPLY_TO` and the recipient address are matched against the anchored `emailRegex`, and `SMTP_FROM_NAME` is both checked in `ParseArgs` and emitted through `mail.Address.String()`, which quotes or RFC 2047-encodes what it is given.
+The builder's own `From:`, `To:` and `Reply-To:` fields do not pass through `ValidateHeaderValue`. They are constrained where they are produced instead: the recipient address is matched against the anchored `emailRegex` in `SendResetEmail`, `SMTP_FROM_ADDRESS` and `EMAIL_REPLY_TO` are parsed with `ValidateConfiguredAddress` in `ParseArgs`, and `SMTP_FROM_NAME` is both checked with `ValidateHeaderValue` in `ParseArgs` and emitted through `mail.Address.String()`, which quotes or RFC 2047-encodes what it is given.
 
 ### 7. Envelope Sender and Delivery Semantics
 
@@ -94,8 +96,8 @@ A cross-domain `From:` header override can break SPF, DKIM and DMARC alignment. 
 
 The two validation layers have different reach, which is worth stating exactly:
 
-- **Unconditional**, in `ParseArgs`: an invalid `EMAIL_REPLY_TO`, an invalid `SMTP_FROM_NAME`, a malformed non-empty `SMTP_FROM_ADDRESS`, an invalid override field name, a control character in an override value, or an override naming a reserved structural header aborts boot with a non-zero exit, whatever `PASSWORD_RESET_ENABLED` is set to.
-- **Only when password reset is enabled**: template resolution, parsing and the dry run happen inside `NewService`, which `buildRPCHandler` constructs only for `PASSWORD_RESET_ENABLED=true`. So a missing template file, a parse error or an undefined field aborts boot only in that case; with the feature off, a broken `EMAIL_TEMPLATE_*` path is never read and the process starts normally.
+- **Unconditional**, in `ParseArgs`: an invalid `SMTP_FROM_NAME`, an invalid override field name, a control character in an override value, or an override naming a reserved structural header aborts boot with a non-zero exit, whatever `PASSWORD_RESET_ENABLED` is set to.
+- **Only when password reset is enabled**: the two address checks — a malformed non-empty `SMTP_FROM_ADDRESS` and an invalid `EMAIL_REPLY_TO` — sit inside `if *fPasswordResetEnabled` in `ParseArgs`. Template resolution, parsing and the dry run happen inside `NewService`, which `buildRPCHandler` constructs only for `PASSWORD_RESET_ENABLED=true`. So a malformed sender or Reply-To, a missing template file, a parse error or an undefined field aborts boot only in that case; with the feature off, neither address is used and a broken `EMAIL_TEMPLATE_*` path is never read, so the process starts normally.
 
 Fallback to embedded defaults applies only to an **unset** template, never to a **broken** one. Silently serving the default in place of a template the operator explicitly configured would hide the misconfiguration behind mail that still appears to work.
 
@@ -149,7 +151,7 @@ type resetEmailData struct {
 
 2. **`Bcc:` is not private**: an override sets a header on the message the requester receives. The name suggests otherwise, and this is documented rather than blocked.
 
-3. **Larger configuration surface**: six new variables plus an open-ended prefix scan, each a place a deployment can get it wrong.
+3. **Larger configuration surface**: five new variables plus an open-ended prefix scan, each a place a deployment can get it wrong.
 
 4. **Empty `SMTP_FROM_ADDRESS` still boots**: the warning-not-error exception above preserves upgrade compatibility at the cost of one misconfiguration that reaches runtime.
 

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -115,49 +115,53 @@ type Opts struct {
 
 ### `internal/ratelimit`
 
-**Purpose**: Rate limiting middleware to prevent abuse of password reset requests.
+**Purpose**: Sliding-window rate limiting to prevent abuse of the password change and reset endpoints.
 
 **Files**:
 
-- `limiter.go` - Rate limiter implementation with IP-based tracking
-- `limiter_test.go` - Comprehensive unit tests (72.3% coverage)
+- `limiter.go` - Generic, key-agnostic sliding-window limiter
+- `ip_limiter.go` - Thin wrapper preconfigured for per-IP limiting
+- `limiter_test.go`, `limiter_internal_test.go`, `ip_limiter_test.go`, `ip_limiter_internal_test.go` - Unit tests
 
 **Key Types**:
 
 ```go
 type Limiter struct {
-    maxRequests int
-    window      time.Duration
-    requests    map[string][]time.Time
-    mu          sync.RWMutex
+    mu             sync.RWMutex
+    entries        map[string]*Entry
+    maxRequests    int
+    window         time.Duration
+    maxIdentifiers int
 }
 ```
 
 **Public API**:
 
-- `NewLimiter(maxRequests int, window time.Duration)` - Create rate limiter
-- `Allow(ip string) bool` - Check if IP is allowed to make request
-- `Reset(ip string)` - Clear rate limit for IP (for testing)
+- `NewLimiter(maxRequests int, window time.Duration) *Limiter` - Create limiter with the default capacity (10000 identifiers)
+- `NewLimiterWithCapacity(maxRequests int, window time.Duration, capacity int) *Limiter` - Create limiter with an explicit capacity
+- `AllowRequest(identifier string) bool` - Check and record a request for an arbitrary key
+- `CleanupExpired() int` / `StartCleanup(interval time.Duration) chan struct{}` - Evict expired entries
+- `Count() int` / `IsFull() bool` - Capacity introspection
+- `NewIPLimiter() *IPLimiter` - Per-IP limiter with a **hardcoded** `NewLimiterWithCapacity(10, 60*time.Minute, 1000)`; it takes no arguments and no environment variable configures it
 
 **Implementation Details**:
 
 - **Sliding window algorithm**: Tracks requests in time window
-- **IP-based**: Uses client IP address as key
+- **Key-agnostic**: `AllowRequest` takes any string; the caller chooses whether it is an IP, a typed identifier, or a resolved account
 - **Thread-safe**: Uses RWMutex for concurrent access
-- **Memory bounded**: Automatic cleanup of expired entries
+- **Memory bounded**: Capacity limit plus automatic cleanup of expired entries; fails closed when at capacity
 
 **Default Configuration**:
 
-- Max requests: 3
-- Time window: 1 hour
-- Per IP address
+- Per-IP limiter: 10 requests / 60 minutes, max 1000 IPs — hardcoded
+- Reset limiter: `RESET_RATE_LIMIT_REQUESTS` (3) / `RESET_RATE_LIMIT_WINDOW_MINUTES` (60), keyed per identifier, not per IP
 
-**Test Coverage**: 72.3%
+**Test Coverage**: 100.0% (`go test -cover ./internal/ratelimit/`)
 
 - ✅ Basic allow/deny logic
 - ✅ Sliding window behavior
 - ✅ Concurrent access
-- ✅ Reset functionality
+- ✅ Capacity limits and expiry cleanup
 - ⚠️ Memory cleanup not fully tested
 
 ---
@@ -269,7 +273,7 @@ Response: {
 
 **Handler**: `internal/rpchandler/request_password_reset.go`
 
-- Rate limiting check (3 requests/hour per IP)
+- Rate limiting check: first per IP (10 requests/hour, hardcoded), then per typed identifier and per resolved account (3 requests/hour by default)
 - Resolve the account per `RESET_IDENTIFIER_MODE` (`email` default, `username`, or `both`).
   In `both`, an input containing `@` is looked up by email, otherwise by username.
 - Generate secure reset token

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -12,7 +12,7 @@ internal/
 ├── options/        # Application configuration and environment variables
 ├── ratelimit/      # Rate limiting middleware for API protection
 ├── resettoken/     # Token generation, storage, and validation
-├── rpc/            # JSON-RPC handlers for all API methods
+├── rpchandler/     # JSON-RPC handlers for all API methods
 ├── validators/     # Password validation rules and enforcement
 └── web/            # Web server, static assets, and templates
 ```
@@ -23,41 +23,52 @@ internal/
 
 ### `internal/email`
 
-**Purpose**: SMTP email service for sending password reset links.
+**Purpose**: Renders and sends the password reset email over SMTP.
 
 **Files**:
 
-- `service.go` - Email service implementation with SMTP configuration
-- `service_test.go` - Unit and integration tests (31.2% coverage)
+- `service.go` - `Config`, `Service`, `NewService`, `SendResetEmail`, reset-link construction, recipient address validation
+- `render.go` - Template loading, parsing and execution for subject, text body and HTML body
+- `message.go` - `multipart/alternative` RFC 5322 message assembly with quoted-printable bodies
+- `headers.go` - Address/header-name/header-value validation, RFC 2047 subject encoding, operator header overrides
+- `templates/` - Embedded defaults: `reset.txt.tmpl` and `reset.html.tmpl`
 
 **Key Types**:
 
 ```go
+type Config struct {
+    SMTPHost, SMTPUsername, SMTPPassword string
+    SMTPPort                             int
+    FromAddress, FromName, ReplyTo       string
+    BaseURL                              string
+    ExpiryMinutes                        uint
+
+    SubjectTemplate  string            // inline template; empty => built-in default
+    TemplateHTMLPath string            // file path; empty => embedded default
+    TemplateTextPath string            // file path; empty => embedded default
+    HeaderOverrides  map[string]string // raw header name => verbatim value
+}
+
 type Service struct {
-    smtpHost     string
-    smtpPort     int
-    smtpUsername string
-    smtpPassword string
-    fromAddress  string
-    fromName     string
+    config   Config
+    renderer *renderer
+    now      func() time.Time // pinned in tests to assert the Date header
 }
 ```
 
 **Public API**:
 
-- `NewService(...)` - Create new email service with SMTP config
-- `SendPasswordResetEmail(to, token, resetURL string)` - Send reset email
+- `NewService(config *Config) (*Service, error)` - Build the service, loading, parsing and dry-running all three templates. Fails fast: a missing, unparseable or field-invalid template is an error here, not at first send.
+- `SendResetEmail(to, token string) error` - Render and send the reset email
+- `ValidateEmailAddress(email string) bool` - Strict regex check for recipient addresses (derived from directory data)
+- `ValidateConfiguredAddress(addr string) error` - Permissive RFC 5322 check for operator-supplied addresses, so senders such as `noreply@localhost` are accepted
+- `ValidateHeaderName(name string) error` / `ValidateHeaderValue(value string) error` - Reject malformed names and control characters in override values
 
-**Dependencies**:
+**Template data** (`resetEmailData`): `ResetLink`, `Token`, `BaseURL`, `Recipient`, `ExpiryMinutes`. Templates are parsed with `missingkey=error`, so an undefined field surfaces during the startup dry-run instead of rendering `<no value>`.
 
-- `net/smtp` - SMTP client
-- Environment variables for configuration
+**Delivery semantics**: `sendEmail` passes a fixed `[]string{to}` to `smtp.SendMail`, so the SMTP envelope recipient is always the reset requester. `To`/`Cc`/`Bcc` overrides are display-only — they add no delivery target, and a `Bcc` override is written as a visible header line in the message the requester receives. `MIME-Version`, `Content-Type` and `Content-Transfer-Encoding` cannot be overridden.
 
-**Test Coverage**: 31.2%
-
-- ✅ Service creation and configuration
-- ✅ Email template rendering
-- ⚠️ Limited SMTP connection testing (requires test server)
+**Dependencies**: `net/smtp`, `net/mail`, `net/textproto`, `mime`, `mime/multipart`, `mime/quotedprintable`, `text/template`, `html/template`, `embed` — all standard library.
 
 ---
 
@@ -67,49 +78,71 @@ type Service struct {
 
 **Files**:
 
-- `app.go` - Configuration struct and environment variable loading
+- `app.go` - `Opts`, `ConfigError`, flag/environment parsing and validation
 
 **Key Types**:
 
 ```go
 type Opts struct {
-    // LDAP Configuration
-    LDAPHost                 string
-    LDAPPort                 int
-    LDAPUseTLS               bool
-    LDAPBaseDN               string
-    LDAPUserAttribute        string
+    Port             string
+    LDAP             ldap.Config // from github.com/netresearch/simple-ldap-go
+    ReadonlyUser     string
+    ReadonlyPassword string
 
-    // Password Policy
-    MinLength                int
-    MinNumbers               int
-    MinSymbols               int
-    MinUppercase             int
-    MinLowercase             int
+    MinLength                  uint
+    MinNumbers                 uint
+    MinSymbols                 uint
+    MinUppercase               uint
+    MinLowercase               uint
     PasswordCanIncludeUsername bool
 
-    // Password Reset Feature
-    PasswordResetEnabled     bool
-    SMTPHost                 string
-    SMTPPort                 int
-    ResetTokenValidityHours  int
+    // Password Reset Configuration
+    PasswordResetEnabled        bool
+    ResetIdentifierMode         ResetIdentifierMode
+    ResetTokenExpiryMinutes     uint
+    ResetRateLimitRequests      uint
+    ResetRateLimitWindowMinutes uint
+    SMTPHost                    string
+    SMTPPort                    uint
+    SMTPUsername                string
+    SMTPPassword                string
+    SMTPFromAddress             string
+    AppBaseURL                  string
 
-    // Server Configuration
-    Port                     int
-    TrustedProxies           []string
+    SMTPFromName         string
+    EmailReplyTo         string
+    EmailTemplateHTML    string
+    EmailTemplateText    string
+    EmailTemplateSubject string
+    SMTPHeaderOverrides  map[string]string
+
+    // Optional dedicated reset account; falls back to ReadonlyUser
+    ResetUser     string
+    ResetPassword string
 }
+
+// ResetIdentifierMode is "email" (default), "username" or "both".
+type ResetIdentifierMode string
 ```
 
 **Public API**:
 
-- `LoadFromEnv()` - Load configuration from environment variables
-- `Validate()` - Validate configuration completeness
+- `Parse() (*Opts, error)` - Parse `os.Args` after loading `.env` / `.env.local`
+- `ParseArgs(args []string) (*Opts, error)` - Same, with an explicit argument slice
+- `MustParse() *Opts` - `Parse`, exiting on error
+- `ConfigError` - Accumulates validation failures; `Add`, `HasErrors`, `Error`
+- `ResetIdentifierMode.Valid() bool` - Reports whether the mode is recognized
 
 **Configuration Sources**:
 
-1. Environment variables (`.env` file)
-2. Default values for optional settings
-3. Validation on startup
+Environment variables supply the _defaults_ of the `flag.FlagSet`, so an
+explicitly passed flag wins over the environment, which wins over the built-in
+default. `godotenv.Load(".env.local", ".env")` runs first and does not overwrite
+variables already present in the process environment. Every validation failure
+is collected into one `ConfigError` rather than aborting at the first.
+
+There is no `TrustedProxies` option; see `internal/rpchandler/ip_extraction.go`
+for the actual, allow-list-free client-IP handling.
 
 ---
 
@@ -156,13 +189,12 @@ type Limiter struct {
 - Per-IP limiter: 10 requests / 60 minutes, max 1000 IPs — hardcoded
 - Reset limiter: `RESET_RATE_LIMIT_REQUESTS` (3) / `RESET_RATE_LIMIT_WINDOW_MINUTES` (60), keyed per identifier, not per IP
 
-**Test Coverage**: 100.0% (`go test -cover ./internal/ratelimit/`)
+**Tested behaviour** (run `go test -cover ./internal/ratelimit/` for the number):
 
 - ✅ Basic allow/deny logic
 - ✅ Sliding window behavior
 - ✅ Concurrent access
 - ✅ Capacity limits and expiry cleanup
-- ⚠️ Memory cleanup not fully tested
 
 ---
 
@@ -173,54 +205,53 @@ type Limiter struct {
 **Files**:
 
 - `token.go` - Cryptographic token generation
-- `token_test.go` - Token generation tests
-- `store.go` - In-memory token storage with expiration
-- `store_test.go` - Comprehensive store tests (71.7% coverage)
+- `store.go` - In-memory token storage with expiration and capacity limit
+- `clock.go` - `Clock` indirection so tests can pin the current time
+- `token_test.go`, `token_fuzz_test.go`, `store_test.go`, `store_internal_test.go`, `clock_test.go` - Tests
 
 **Key Types**:
 
 ```go
-// Token generation
-func GenerateToken() (string, error)
-
-// Token storage
-type Store struct {
-    tokens map[string]TokenData
-    mu     sync.RWMutex
+type ResetToken struct {
+    Token            string
+    Username         string
+    Email            string
+    CreatedAt        time.Time
+    ExpiresAt        time.Time
+    Used             bool
+    RequiresApproval bool
 }
 
-type TokenData struct {
-    Email     string
-    ExpiresAt time.Time
+type Store struct {
+    mu     sync.RWMutex
+    tokens map[string]*ResetToken
 }
 ```
 
 **Public API**:
 
 ```go
-// Token operations
-GenerateToken() (string, error)           // Generate 256-bit secure token
-NewStore() *Store                         // Create token store
-Store(token, email string, ttl time.Duration) // Store token with expiration
-Validate(token string) (email string, error)  // Validate and consume token
-Delete(token string)                      // Explicitly delete token
+GenerateToken() (string, error)                          // 32 random bytes, URL-safe base64
+NewStore() *Store                                        // Create token store
+(*Store) Store(token *ResetToken) error                  // Insert; rejects duplicates and over-capacity
+(*Store) Get(tokenString string) (*ResetToken, error)    // Look up; does not consume
+(*Store) MarkUsed(tokenString string) error              // Flag a token as spent
+(*Store) Delete(tokenString string) error                // Remove a token
+(*Store) CleanupExpired() int                            // Evict expired tokens
+(*Store) StartCleanup(interval time.Duration) chan struct{}
+(*Store) Count() int
+(*Store) IsFull() bool
+(*ResetToken) IsExpired() bool
 ```
 
 **Security Features**:
 
-- **Cryptographically secure**: Uses `crypto/rand` for token generation
-- **256-bit tokens**: Encoded as URL-safe base64 (43 characters)
-- **Time-limited**: Configurable TTL (default 24 hours)
-- **Single-use**: Tokens deleted after successful validation
-- **Automatic expiration**: Background cleanup of expired tokens
-
-**Test Coverage**: 71.7%
-
-- ✅ Token generation and uniqueness
-- ✅ Store/validate/delete operations
-- ✅ Expiration handling
-- ✅ Concurrent access
-- ⚠️ Edge cases for cleanup timing
+- **Cryptographically secure**: `crypto/rand` for token generation
+- **256-bit tokens**: 32 random bytes, URL-safe base64 without padding (43 characters)
+- **Time-limited**: `ExpiresAt` set by the caller from `RESET_TOKEN_EXPIRY_MINUTES` (default 15 minutes)
+- **Single-use**: `reset_password` calls `MarkUsed` after a successful reset; the entry stays in the store until it expires and cleanup removes it
+- **Capacity bounded**: `maxCapacity` is 10000 entries. At capacity the store first evicts expired tokens and, failing that, rejects the new token — it never evicts a live one
+- **Automatic expiration**: `StartCleanup` runs background eviction
 
 ---
 
@@ -234,9 +265,9 @@ Delete(token string)                      // Explicitly delete token
 - `dto.go` - Data transfer objects for RPC methods
 - `change_password.go` - Password change RPC handler
 - `request_password_reset.go` - Request reset token handler
-- `request_password_reset_test.go` - Reset request tests
 - `reset_password.go` - Complete password reset handler
-- `reset_password_test.go` - Password reset tests
+- `ip_extraction.go` - Client-IP resolution for the per-IP rate limiter
+- `password_validation.go` - Server-side password policy enforcement
 
 **RPC Methods**:
 
@@ -304,56 +335,50 @@ Response: {
 - Retrieve user email from token store
 - Lookup user DN in LDAP
 - Reset password via LDAP admin bind
-- Delete token after successful reset
+- Mark the token used (`Store.MarkUsed`) after a successful reset; the entry is
+  removed later by expiry cleanup, not here
 
-**Test Coverage**: 45.6%
+**Tested behaviour** (run `go test -cover ./internal/rpchandler/` for the number):
 
 - ✅ Happy path for all methods
 - ✅ Error handling for invalid inputs
-- ✅ LDAP integration with testcontainers
-- ⚠️ Edge cases and error conditions partially covered
+- ✅ Fuzz tests for client-IP extraction and password validation
+- ✅ LDAP integration behind the `integration` build tag, against a real server
 
 ---
 
 ### `internal/validators`
 
-**Purpose**: Password validation rules matching server-side policy.
+**Purpose**: Character-class counting predicates used by the server-side password policy.
 
 **Files**:
 
 - `validate.go` - Validation rule implementations
-- `validate_test.go` - Comprehensive validation tests (100% coverage)
+- `validate_test.go` - Validation tests
 
 **Public API**:
 
 ```go
-// Validation functions
-ValidateMinLength(password string, minLength int) error
-ValidateMinNumbers(password string, minNumbers int) error
-ValidateMinSymbols(password string, minSymbols int) error
-ValidateMinUppercase(password string, minUppercase int) error
-ValidateMinLowercase(password string, minLowercase int) error
-ValidateNoUsername(password, username string) error
-
-// Combined validation
-ValidatePassword(password, username string, opts *options.Opts) error
+MinNumbersInString(value string, amount uint) bool
+MinSymbolsInString(value string, amount uint) bool
+MinUppercaseLettersInString(value string, amount uint) bool
+MinLowercaseLettersInString(value string, amount uint) bool
 ```
 
-**Validation Rules**:
+Each returns a bool, not an error, and counts ASCII runes only. The package holds
+no minimum-length or username check: those, and the human-readable error
+messages, live in `rpchandler.ValidateNewPassword`, which composes these four
+predicates with `opts`.
 
-- ✅ Minimum length (configurable, default 8)
-- ✅ Minimum numbers (configurable, default 1)
-- ✅ Minimum symbols (configurable, default 1)
-- ✅ Minimum uppercase (configurable, default 1)
-- ✅ Minimum lowercase (configurable, default 1)
-- ✅ Username exclusion (optional, default enabled)
+**Validation Rules** (defaults from `internal/options`):
 
-**Test Coverage**: 100% ✅
-
-- All validation rules tested
-- Edge cases covered
-- Combined validation tested
-- Configuration variations tested
+- ✅ Minimum length (`MIN_LENGTH`, default 8) — enforced in `rpchandler`
+- ✅ Maximum length — `rpchandler.MaxPasswordLength`, a hardcoded 128, not configurable
+- ✅ Minimum numbers (`MIN_NUMBERS`, default 1)
+- ✅ Minimum symbols (`MIN_SYMBOLS`, default 1)
+- ✅ Minimum uppercase (`MIN_UPPERCASE`, default 1)
+- ✅ Minimum lowercase (`MIN_LOWERCASE`, default 1)
+- ✅ Username exclusion (`PASSWORD_CAN_INCLUDE_USERNAME`, default false, i.e. excluded) — enforced in `rpchandler`
 
 ---
 
@@ -366,14 +391,22 @@ ValidatePassword(password, username string, opts *options.Opts) error
 ```
 web/
 ├── static/
-│   ├── js/
+│   ├── js/                     # .ts sources plus the .js tsc emits beside them
 │   │   ├── app.ts              # Main page (password change)
 │   │   ├── forgot-password.ts  # Password reset request
 │   │   ├── reset-password.ts   # Password reset completion
+│   │   ├── *-init.ts           # Per-page bootstrap entry points
+│   │   ├── theme-init.ts       # Theme applied before first paint
+│   │   ├── density-init.ts     # Density applied before first paint
+│   │   ├── toggles.ts          # Theme/density toggle wiring
+│   │   ├── policy-ui.ts        # Password policy checklist rendering
+│   │   ├── error-utils.ts      # Shared error formatting
 │   │   └── validators.ts       # Client-side validation
+│   ├── static.go               # embed.FS for this directory
 │   ├── styles.css              # Compiled Tailwind CSS
 │   ├── favicon.ico             # Browser favicon
-│   ├── *.png                   # PWA icons
+│   ├── *.png, logo.webp, safari-pinned-tab.svg
+│   ├── browserconfig.xml
 │   └── site.webmanifest        # PWA manifest
 ├── templates/
 │   ├── atoms/                  # Basic UI components
@@ -445,8 +478,9 @@ web/
 
 ```go
 RenderIndex(opts *options.Opts) ([]byte, error)
-RenderForgotPassword() ([]byte, error)
+RenderForgotPassword(opts *options.Opts) ([]byte, error)
 RenderResetPassword(opts *options.Opts) ([]byte, error)
+MakeInputOpts(name, placeholder, inputType, autocomplete, help string) InputOpts
 ```
 
 **Features**:
@@ -465,8 +499,7 @@ RenderResetPassword(opts *options.Opts) ([]byte, error)
 **TypeScript → JavaScript**:
 
 ```bash
-tsc                    # Compile TypeScript
-uglify-js             # Minify for production
+tsc                    # Compile TypeScript; no minifier is configured
 ```
 
 **Tailwind CSS → CSS**:
@@ -504,53 +537,62 @@ var staticFS embed.FS
 
 ### Go Dependencies (go.mod)
 
-**Direct**:
+**Direct** (the full `require` block of `go.mod`):
 
-- `github.com/gofiber/fiber/v2` - Web framework
+- `github.com/gofiber/fiber/v3` - Web framework
 - `github.com/joho/godotenv` - Environment variable loading
 - `github.com/netresearch/simple-ldap-go` - LDAP client
-
-**Testing**:
-
-- `github.com/testcontainers/testcontainers-go` - Integration testing
-- `github.com/testcontainers/testcontainers-go/modules/openldap` - LDAP test server
+- `github.com/valyala/fasthttp` - HTTP engine under Fiber
 - `github.com/stretchr/testify` - Test assertions
+
+There is no testcontainers dependency. Integration tests are gated by the
+`integration` build tag and talk to services the developer or CI already
+started; see the Testing Strategy section below.
 
 ### Node Dependencies (package.json)
 
+All are `devDependencies`; the package has no runtime `dependencies`.
+
 **Build Tools**:
 
-- `typescript` - Type-safe JavaScript
-- `@tailwindcss/postcss` - CSS framework
-- `uglify-js` - JavaScript minification
-- `postcss` - CSS processing (minification via @tailwindcss/postcss / Lightning CSS)
+- `typescript` - Type-safe JavaScript; `tsc` is the only JS build step, and no minifier is configured
+- `tailwindcss` / `@tailwindcss/postcss` - CSS framework (minification via Lightning CSS)
+- `postcss` / `postcss-cli` - CSS processing
 
 **Development**:
 
-- `concurrently` - Parallel script execution
-- `nodemon` - File watching and hot reload
-- `prettier` - Code formatting
+- `eslint`, `typescript-eslint`, `@eslint/js`, `eslint-config-prettier` - Linting
+- `prettier`, `prettier-plugin-go-template`, `prettier-plugin-tailwindcss` - Code formatting
+
+`bun run dev` also invokes `air` for Go hot-reload; `air` is not declared in
+`package.json` and must be installed separately.
 
 ---
 
 ## Testing Strategy
 
+Per-package coverage percentages are not listed here — they go stale faster than
+anyone updates them. Run `go test -cover ./...`, or read the
+[Codecov dashboard](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer).
+
 ### Unit Tests
 
-- **Package**: `internal/validators` - 100% coverage ✅
-- **Package**: `internal/ratelimit` - 72.3% coverage
-- **Package**: `internal/resettoken` - 71.7% coverage
+- Default build, no tags: `go test ./...`
+- `*_internal_test.go` files test unexported behaviour from inside the package
+- `*_fuzz_test.go` files cover client-IP extraction, password validation and email input
 
 ### Integration Tests
 
-- **Package**: `internal/rpchandler` - 45.6% coverage
-- **Package**: `internal/email` - 31.2% coverage
-- Uses testcontainers for real LDAP server
-- Tests complete RPC workflows
+- Build tag `integration`; `make test-integration` runs `go test -v -race -tags=integration ./...`
+- Backing services come from `docker compose --profile test up`
+- Configured through the same environment variables as the app; a test whose
+  variables are unset skips instead of failing
 
 ### E2E Tests
 
-- Recommended: Playwright for browser automation
+- Build tag `e2e`, in `e2e/e2e_test.go`; `make test-e2e` runs
+  `go test -v -race -tags=e2e ./e2e/...`
+- Go and `httptest` against the assembled Fiber app — no browser automation
 - See [Testing Guide](testing-guide.md) for setup
 
 ---
@@ -607,7 +649,10 @@ See [Security Documentation](security.md) for comprehensive security architectur
 - `internal/resettoken` - Cryptographic token generation
 - `internal/validators` - Input validation
 - LDAPS support in LDAP client
-- CSRF protection in Fiber middleware
+
+There is no CSRF middleware: nothing in the tree references `csrf`, and the
+security assessments record it as an accepted, unimplemented finding
+(`docs/security-assessment-revised-2025-10-09.md`, WAF-02).
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -369,9 +369,11 @@ docker run -v /etc/ssl/certs:/etc/ssl/certs:ro ...
 
 ### Secrets as files: not supported
 
-**The application reads secrets from environment variables only.** Every option
-is parsed with `os.LookupEnv` in `internal/options/app.go`; there is no `*_FILE`
-variant of any variable. `LDAP_READONLY_PASSWORD_FILE`,
+**The application reads secrets from environment variables or CLI flags only.**
+In `internal/options/app.go` each environment variable supplies the _default_ of
+a `flag.FlagSet` entry, so an explicitly passed flag overrides the environment.
+Either way the value is a string in the process environment or argv — there is no
+`*_FILE` variant of any variable. `LDAP_READONLY_PASSWORD_FILE`,
 `LDAP_RESET_PASSWORD_FILE` and `SMTP_PASSWORD_FILE` configure nothing. How that
 fails depends on whether the underlying option is required:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -174,12 +174,20 @@ RESET_IDENTIFIER_MODE=email
 # Token expiry in minutes (default: 15)
 RESET_TOKEN_EXPIRY_MINUTES=15
 
-# Rate limit: max requests per IP (default: 3)
+# Reset rate limit: max requests per identifier (default: 3)
+# Counted per typed identifier and per resolved account — NOT per IP.
 RESET_RATE_LIMIT_REQUESTS=3
 
-# Rate limit: time window in minutes (default: 60)
+# Reset rate limit: time window in minutes (default: 60)
 RESET_RATE_LIMIT_WINDOW_MINUTES=60
 ```
+
+The separate **per-IP** limiter — 10 requests per 60 minutes, at most 1000
+tracked IPs, applied to both `change-password` and `request-password-reset` —
+is hardcoded in `internal/ratelimit/ip_limiter.go`. No environment variable
+configures it; there is no `RATE_LIMIT_*` prefix. Changing it requires a code
+change and a rebuild. To cap request rates without rebuilding, rate-limit at
+the reverse proxy instead — see the Reverse Proxy Configuration section below.
 
 #### SMTP Configuration
 
@@ -254,11 +262,39 @@ Delivery semantics:
 ```bash
 # HTTP port (default: 3000)
 PORT=3000
-
-# Trusted proxy IPs (optional, comma-separated)
-TRUSTED_PROXIES=192.168.1.1,10.0.0.0/8
-# Required if behind reverse proxy for accurate client IP detection
 ```
+
+`PORT` is the only server-level variable the application reads.
+
+##### Client IP detection (no trusted-proxy allow-list)
+
+There is no `TRUSTED_PROXIES` option. `internal/rpchandler/ip_extraction.go`
+determines the client IP used for the per-IP rate limiter by taking the first
+valid IP address among:
+
+1. the leftmost entry of `X-Forwarded-For`,
+2. `X-Real-IP`,
+3. the direct connection address (`fiber.Ctx.IP()`),
+
+falling back to `0.0.0.0` if none parses. Both headers are honoured no matter
+who sent them — `fiber.New` in `main.go` sets no `TrustProxy` configuration and
+nothing validates the immediate peer.
+
+**Consequence:** a caller that can set its own `X-Forwarded-For` chooses its own
+rate-limit bucket, and by varying the value defeats the per-IP limit entirely.
+Two deployment rules follow:
+
+- **Never expose the application port directly.** Bind it to the loopback
+  interface or a private network and put a reverse proxy in front.
+- **The proxy must overwrite `X-Forwarded-For`, not append to it.** The nginx
+  example below uses `$proxy_add_x_forwarded_for`, which appends the peer
+  address to whatever the client sent — the client-supplied value stays
+  leftmost and is therefore the one this application trusts. Replace it with
+  `proxy_set_header X-Forwarded-For $remote_addr;` when clients reach the proxy
+  directly. The Apache example below already overwrites the header
+  (`RequestHeader set X-Forwarded-For "%{REMOTE_ADDR}s"`). For the Traefik
+  example, set `forwardedHeaders.trustedIPs` on the entrypoint so incoming
+  values are only honoured from your own proxies.
 
 ### Configuration Files
 
@@ -331,29 +367,37 @@ cat ldap-ca.crt >> /etc/ssl/certs/ca-certificates.crt
 docker run -v /etc/ssl/certs:/etc/ssl/certs:ro ...
 ```
 
-### Docker Secrets (Swarm/Kubernetes)
+### Secrets as files: not supported
 
-```yaml
-# Use Docker secrets for sensitive data
-services:
-  ldap-passwd:
-    image: ghcr.io/netresearch/ldap-selfservice-password-changer:latest
-    secrets:
-      - ldap_readonly_password
-      - ldap_reset_password
-      - smtp_password
-    environment: LDAP_READONLY_PASSWORD_FILE=/run/secrets/ldap_readonly_password
-      LDAP_RESET_PASSWORD_FILE=/run/secrets/ldap_reset_password
-      SMTP_PASSWORD_FILE=/run/secrets/smtp_password
+**The application reads secrets from environment variables only.** Every option
+is parsed with `os.LookupEnv` in `internal/options/app.go`; there is no `*_FILE`
+variant of any variable. `LDAP_READONLY_PASSWORD_FILE`,
+`LDAP_RESET_PASSWORD_FILE` and `SMTP_PASSWORD_FILE` configure nothing. How that
+fails depends on whether the underlying option is required:
 
-secrets:
-  ldap_readonly_password:
-    external: true
-  ldap_reset_password:
-    external: true
-  smtp_password:
-    external: true
-```
+- `LDAP_READONLY_PASSWORD` is required, so substituting the `_FILE` form aborts
+  startup with `required options missing: readonly-password` — confusing, since
+  the operator did supply a secret, but at least loud.
+- `LDAP_RESET_PASSWORD` and `SMTP_PASSWORD` are optional, so their `_FILE`
+  forms fail **silently**: the container starts with an empty value and the
+  reset bind or SMTP authentication fails later, at request time.
+
+Nor can this be worked around with an entrypoint wrapper in the published
+image: the runtime stage is `FROM scratch` with the binary itself as
+`ENTRYPOINT` (see [`Dockerfile`](../Dockerfile)), so there is no shell available
+to read a file and export it.
+
+Supply secrets as environment variables instead:
+
+- **Kubernetes** — inject them with `secretKeyRef`, as in the Deployment
+  manifest below. This is the recommended production path.
+- **Docker Swarm** — Swarm mounts secrets as files, so it cannot feed this
+  application directly. Either resolve the values into `environment:` at deploy
+  time from your own secret store, or build a derived image on a base that has
+  a shell and add an entrypoint that exports the file contents before exec'ing
+  the binary.
+- **Plain Docker / Compose** — use an `env_file` with restrictive permissions,
+  kept out of version control (see `.env.local`).
 
 ---
 
@@ -1100,12 +1144,19 @@ curl -v --url "smtp://$SMTP_HOST:$SMTP_PORT" \
 docker restart ldap-passwd
 ```
 
-**Adjust rate limits**:
+**Adjust the per-identifier reset limit**:
 
 ```bash
 RESET_RATE_LIMIT_REQUESTS=10
 RESET_RATE_LIMIT_WINDOW_MINUTES=60
 ```
+
+If users are blocked despite a raised `RESET_RATE_LIMIT_REQUESTS`, the per-IP
+limiter is the likely cause: it allows 10 requests per hour per client IP, is
+hardcoded, and applies to `change-password` as well. Behind a proxy that does
+not forward a per-client `X-Forwarded-For`, every user shares one bucket. There
+is no environment variable for it — check the proxy's header handling first
+(see the Client IP detection section above).
 
 ### Password Policy Errors
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -6,7 +6,7 @@ Progressive learning path for new developers joining the LDAP Selfservice Passwo
 
 Before starting, ensure you have:
 
-- [ ] Go 1.24+ installed (`go version`)
+- [ ] Go 1.26+ installed (`go version`) — matches the `go` directive in `go.mod`
 - [ ] Bun installed (`bun --version`) — package manager and JavaScript runtime for the frontend build
 - [ ] Git configured with your credentials
 - [ ] Access to LDAP/AD test server (or credentials for development)

--- a/docs/security.md
+++ b/docs/security.md
@@ -461,8 +461,10 @@ SMTP_PASSWORD=secret
 - ✅ Rotate credentials regularly
 - ✅ Use secret managers in production (Vault, AWS Secrets Manager)
 
-**Secrets are read from environment variables only.** `internal/options/app.go`
-resolves every option with `os.LookupEnv`; no `*_FILE` variant exists, so a
+**Secrets are read from environment variables or CLI flags only.** In
+`internal/options/app.go` each environment variable supplies the default of a
+`flag.FlagSet` entry, so a passed flag wins over the environment; no `*_FILE`
+variant exists either way, so a
 file-mounted secret (Docker Swarm `/run/secrets/...`) cannot be consumed
 directly. A `..._FILE` variable configures nothing — for the optional
 `LDAP_RESET_PASSWORD` and `SMTP_PASSWORD` it fails silently and leaves the

--- a/docs/security.md
+++ b/docs/security.md
@@ -102,10 +102,10 @@ Time to guess: 2^256 / 1000 ≈ 10^73 years
 **Mitigations**:
 
 - Always return success response regardless of identifier validity
-- Rate limiting prevents mass enumeration (3 requests/hour per IP)
+- Rate limiting prevents mass enumeration: 10 requests/hour per IP, plus 3 requests/hour per typed identifier (`RESET_RATE_LIMIT_REQUESTS`)
 - No timing differences between valid/invalid identifiers
 
-**Residual Risk**: Medium - rate limiting can be circumvented with distributed IPs
+**Residual Risk**: Medium - the per-identifier limit does not slow enumeration across many different identifiers, and the per-IP limit can be circumvented with distributed IPs or by spoofing `X-Forwarded-For` when the application is reachable without a header-overwriting proxy
 
 **Detection**: Monitor for:
 
@@ -121,8 +121,8 @@ Time to guess: 2^256 / 1000 ≈ 10^73 years
 
 **Mitigations**:
 
-- Rate limiting per IP address (3 requests/hour for reset)
-- Reverse proxy rate limiting (recommended 10 req/sec globally)
+- Rate limiting per IP address: 10 requests/hour, on both the change and reset endpoints
+- Reverse proxy rate limiting (recommended 10 req/sec globally) — the only rate limit that is tunable without a rebuild
 - Lightweight Go application with low resource footprint
 - Stateless design enables horizontal scaling
 
@@ -370,20 +370,30 @@ export const isValidEmail = (email: string): string => {
 
 ```go
 type Limiter struct {
-    maxRequests int           // 3 (default)
-    window      time.Duration // 1 hour (default)
-    requests    map[string][]time.Time // IP -> timestamps
-    mu          sync.RWMutex
+    mu             sync.RWMutex
+    entries        map[string]*Entry // identifier -> recent timestamps
+    maxRequests    int               // Maximum requests allowed in window
+    window         time.Duration     // Time window for rate limiting
+    maxIdentifiers int               // Capacity limit on tracked identifiers
 }
 
-func (l *Limiter) Allow(ip string) bool {
+func (l *Limiter) AllowRequest(identifier string) bool {
     // Sliding window algorithm
     // Remove expired requests
-    // Check if under limit
+    // Check if under limit; fail closed when at capacity
 }
 ```
 
-**Configuration**:
+`Limiter` is key-agnostic — the caller decides what `identifier` means. Two
+instances are created, with different keys and different configurability:
+
+| Limiter                             | Key                                               | Limit                     | Endpoints                                   | Configurable                                                         |
+| ----------------------------------- | ------------------------------------------------- | ------------------------- | ------------------------------------------- | -------------------------------------------------------------------- |
+| `ratelimit.NewIPLimiter()`          | client IP from `extractClientIP`                  | 10 / 60 min, max 1000 IPs | `change-password`, `request-password-reset` | **No** — hardcoded in `internal/ratelimit/ip_limiter.go`             |
+| `ratelimit.NewLimiter(...)` (reset) | `typed:<input>` and `account:<resolved username>` | 3 / 60 min (defaults)     | `request-password-reset`                    | Yes — `RESET_RATE_LIMIT_REQUESTS`, `RESET_RATE_LIMIT_WINDOW_MINUTES` |
+
+**Configuration** (per-identifier reset limiter only — there is no
+`RATE_LIMIT_*` prefix and no variable for the per-IP limiter):
 
 ```bash
 RESET_RATE_LIMIT_REQUESTS=3
@@ -392,11 +402,10 @@ RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
 **Properties**:
 
-- ✅ Per-IP rate limiting
 - ✅ Sliding window algorithm (more accurate than fixed window)
 - ✅ Automatic cleanup of expired entries
 - ✅ Thread-safe concurrent access
-- ✅ Memory-bounded (old entries cleaned)
+- ✅ Memory-bounded (capacity limit plus cleanup of old entries)
 
 **Effectiveness**:
 
@@ -406,8 +415,10 @@ RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
 **Limitations**:
 
-- IP-based (can be circumvented with proxies/VPNs)
+- The per-IP key is derived from `X-Forwarded-For`/`X-Real-IP` with no trusted-proxy allow-list, so it can be spoofed unless a reverse proxy overwrites those headers
+- IP-based limits can be circumvented with proxies/VPNs
 - Shared IP (NAT) may affect legitimate users
+- The per-IP limit cannot be tuned without a rebuild
 - Recommend: Combine with reverse proxy rate limiting
 
 ### Transport Security
@@ -450,13 +461,13 @@ SMTP_PASSWORD=secret
 - ✅ Rotate credentials regularly
 - ✅ Use secret managers in production (Vault, AWS Secrets Manager)
 
-**Docker Secrets** (Swarm/Kubernetes):
-
-```yaml
-environment: LDAP_READONLY_PASSWORD_FILE=/run/secrets/ldap_password
-secrets:
-  - ldap_password
-```
+**Secrets are read from environment variables only.** `internal/options/app.go`
+resolves every option with `os.LookupEnv`; no `*_FILE` variant exists, so a
+file-mounted secret (Docker Swarm `/run/secrets/...`) cannot be consumed
+directly. A `..._FILE` variable configures nothing — for the optional
+`LDAP_RESET_PASSWORD` and `SMTP_PASSWORD` it fails silently and leaves the
+credential empty. In Kubernetes, inject secrets as environment variables with
+`secretKeyRef`. See [deployment.md](deployment.md) for the details.
 
 **Logging Safety**:
 

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -79,7 +79,6 @@ PORT=3000
 
 - `github.com/gofiber/fiber/v3` - HTTP server
 - `github.com/netresearch/simple-ldap-go` - LDAP client
-- `github.com/testcontainers/testcontainers-go` - Integration testing
 - `github.com/joho/godotenv` - Environment loading
 
 ## Build & Tests
@@ -96,8 +95,8 @@ go test ./internal/ratelimit/...     # Test rate limiter
 go test ./internal/resettoken/...    # Test token generation
 go test -run TestSpecificFunction    # Run specific test
 
-# Integration tests (uses testcontainers)
-go test -v ./internal/email/...      # Requires Docker for MailHog container
+# Integration tests (build-tagged; skipped unless the services are reachable)
+SMTP_HOST=localhost go test -tags=integration -v ./internal/email/...   # needs Mailpit
 
 # Coverage
 go test -cover ./...                 # Coverage summary
@@ -167,7 +166,7 @@ conn, _ := ldap.Dial(url)
 **Testing**:
 
 - Table-driven tests preferred
-- Use testcontainers for external dependencies (LDAP, SMTP)
+- Integration tests are build-tagged `integration` and gated on env vars (e.g. `SMTP_HOST`); there is no testcontainers dependency, so they skip silently when the service is absent
 - Test files colocated with code: `validators/validate_test.go`
 - Descriptive test names: `TestPasswordValidation_RequiresMinimumLength`
 
@@ -343,7 +342,7 @@ func ResetPassword(username string) error {
 2. **Import errors**: Check `go.mod` requires correct versions
 3. **Test failures**: `go test -v ./... -run FailingTest` for verbose output
 4. **LDAP connection**: Verify `LDAP_SERVER` format and network access
-5. **Email testing**: Ensure Docker running for testcontainers (MailHog)
+5. **Email testing**: integration tests need a reachable Mailpit and `SMTP_HOST` set; without them they skip rather than fail
 6. **Rate limit testing**: Tests may fail if system time incorrect
 
 **Debugging**:
@@ -374,8 +373,7 @@ go build -gcflags="all=-N -l"
 
 ### email/
 
-- Uses testcontainers for integration tests
-- MailHog container spins up automatically in tests
+- Integration tests are behind the `integration` build tag and talk to Mailpit over SMTP + its HTTP API; nothing spins a container up for you (see `compose.yml`, `dev` profile)
 - Mock `EmailService` interface for unit tests in other packages
 - `NewService` returns `(*Service, error)` and validates templates at startup (parse + dry-run); template fields are `ResetLink`, `Token`, `BaseURL`, `Recipient`, `ExpiryMinutes`
 - **To/Cc/Bcc overrides are display-only.** `sendEmail` passes a fixed `[]string{to}` to `smtp.SendMail`, so the SMTP envelope recipient is always the reset requester — `SMTP_HEADER_OVERRIDE_BCC` does **not** add a delivery target. `buildMIMEMessage` still writes it as a real, visible `Bcc:` header line in the mail the requester receives, so an address put there gains no delivery _and_ is disclosed to the user — never configure one that must stay hidden.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -12,7 +12,7 @@ Backend services for LDAP selfservice password change/reset functionality. Organ
 
 - **email/**: SMTP email service for password reset tokens
 - **options/**: Configuration management from environment variables
-- **ratelimit/**: IP-based rate limiting (3 req/hour default)
+- **ratelimit/**: sliding-window limiting. `Limiter` is generic over a string key; `IPLimiter` wraps it with a hardcoded 10 req/60 min/1000-IP configuration
 - **resettoken/**: Cryptographic token generation and validation
 - **rpchandler/**: JSON-RPC 2.0 API handlers (password change/reset) — renamed from `rpc/` to avoid Go stdlib `net/rpc` conflict
 - **validators/**: Password policy validation logic
@@ -52,7 +52,9 @@ EMAIL_TEMPLATE_HTML=/config/email/reset.html
 EMAIL_TEMPLATE_TEXT=/config/email/reset.txt
 # Raw header escape hatch (suffix _ -> -): SMTP_HEADER_OVERRIDE_X_HELPDESK_TOPIC=...
 
-# Rate limiting (optional; window is in minutes, not a duration string)
+# Rate limiting for the reset flow, per identifier (optional; window is in
+# minutes, not a duration string). The separate per-IP limiter is hardcoded —
+# no environment variable configures it, and there is no RATE_LIMIT_* prefix.
 RESET_RATE_LIMIT_REQUESTS=3
 RESET_RATE_LIMIT_WINDOW_MINUTES=60
 
@@ -192,12 +194,12 @@ conn, _ := ldap.Dial(url)
 - Single-use tokens (invalidated after use)
 - No token storage in logs or metrics
 
-**Rate Limiting**:
+**Rate Limiting** — two distinct limiters, keep them apart:
 
-- IP-based limits: 3 requests per 60-minute window by default
-- Configurable via `RESET_RATE_LIMIT_REQUESTS` / `RESET_RATE_LIMIT_WINDOW_MINUTES`
-- In-memory store (consider Redis for multi-instance)
-- Apply to both change and reset endpoints
+- **Per-IP** (`ratelimit.NewIPLimiter`): 10 requests per 60-minute window, at most 1000 tracked IPs. Hardcoded in `ratelimit/ip_limiter.go`; **not** configurable by any environment variable. Applied to both the change and the reset endpoint.
+- **Per-identifier, reset only** (`ratelimit.NewLimiter`): `RESET_RATE_LIMIT_REQUESTS` (default 3) per `RESET_RATE_LIMIT_WINDOW_MINUTES` (default 60). Keyed by the typed identifier (`typed:` prefix) and again by the resolved account (`account:` prefix) — never by IP.
+- Both are in-memory (consider Redis for multi-instance)
+- The client IP fed to the per-IP limiter comes from `rpchandler.extractClientIP`, which trusts `X-Forwarded-For`/`X-Real-IP` from any source — see the note in `rpchandler/` below.
 
 **Input Validation**:
 
@@ -391,6 +393,8 @@ go build -gcflags="all=-N -l"
 - In-memory store (map with mutex)
 - Consider Redis for multi-instance deployments
 - Tests use fixed time.Now for deterministic results
+- `Limiter` is key-agnostic (`AllowRequest(identifier string)`); the caller chooses the key. `NewLimiter` caps tracked identifiers at `maxIdentifiers` (10000); `NewLimiterWithCapacity` takes the cap explicitly.
+- **`IPLimiter` is not configurable.** `NewIPLimiter()` takes no arguments and hardcodes `NewLimiterWithCapacity(10, 60*time.Minute, 1000)`. Changing the per-IP limit requires a code change, not an env var.
 
 ### resettoken/
 
@@ -406,6 +410,7 @@ go build -gcflags="all=-N -l"
 - Error codes defined in [docs/api-reference.md](../docs/api-reference.md)
 - Request validation before processing
 - Endpoint: `POST /api/rpc`
+- **`extractClientIP` trusts proxy headers unconditionally.** It returns the first valid IP among the leftmost `X-Forwarded-For` value, `X-Real-IP`, and `fiber.Ctx.IP()`, falling back to `0.0.0.0`. There is no trusted-proxy allow-list — `fiber.New` in `main.go` sets no `TrustProxy`, and no option reads one. Any client that can reach the app directly picks its own per-IP rate-limit bucket by setting the header, so the app must not be exposed without a proxy that **overwrites** `X-Forwarded-For`.
 
 ### Health Check
 


### PR DESCRIPTION
## Description

Four PRs (#629, #630, #631, #632) merged into `main` in quick succession, each verified on its own branch and never together. Git merged them without conflict, but "no textual conflict" is not "coherent" — three of them independently edited `README.md`, `CONTRIBUTING.md` and `PROJECT-INDEX.md`, and the combined result contradicted itself in ways none of the individual PRs contained.

This fixes what a post-merge audit of `main` found. **No code changes** — the shipped code was correct in every case; the documents had drifted away from it.

## Type of Change

- [x] 📝 Documentation update
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## Changes Made

### The precedence rule was corrected in one file and left inverted in another

`docs/development-guide.md` was fixed by #631 to say that Compose's inline `environment:` block wins over `env_file`. `.env.local.example` — the file an operator actually edits — still said the opposite: _"This file is loaded AFTER the defaults, so any value you uncomment wins."_ Of the 30 commented entries it offers, **23 are inert** because they are pinned inline in `compose.yml`.

Re-deriving the split turned up a third category the original analysis missed: `APP_PORT` and `MAILPIT_WEB_PORT` are Compose _interpolation_ variables, and `env_file` is not a substitution source, so `.env.local` cannot set them either. Verified with `docker compose config`. The file is now split three ways — effective here, edit `compose.yml`, and shell/`.env` only.

### ADR 0003 contradicted itself and the code

It declared the `SMTP_FROM_ADDRESS`/`EMAIL_REPLY_TO` checks unconditional while its own later section said they are gated on `PASSWORD_RESET_ENABLED` — which is what `internal/options/app.go:392` actually does. It also named `ValidateEmailAddress`/`emailRegex` for `EMAIL_REPLY_TO`, where the code deliberately uses the permissive `ValidateConfiguredAddress` so internal domains are accepted. Both are refuted by tests already on `main`.

### Three capabilities were documented but not implemented

- **`RATE_LIMIT_*`** — no such prefix exists. The per-IP limiter is hardcoded at 10 requests/hour in `internal/ratelimit/ip_limiter.go`, not the documented 3, and is not configurable. The genuinely configurable `RESET_RATE_LIMIT_*` per-identifier limiter is now clearly distinguished from it.
- **`TRUSTED_PROXIES`** — never read by the code.
- **Docker secrets `*_FILE`** — no implementation. The recipe is removed rather than reworked: the runtime stage is `FROM scratch` with the binary as `ENTRYPOINT`, so there is no shell to read a file and export it. Replaced with `secretKeyRef`/`env_file` guidance and an explicit Swarm caveat.

### Stale content

Coverage tables asserting figures #629 falsified (`internal/email` listed at 31.2%, actually 87.3%), `docs/code-structure.md` describing `internal/email` as it was before the feature rebuilt it, badge lines stranded inside a bash code fence in `README.md`, a Go version floor disagreeing with `go.mod`, and links into a `claudedocs/` directory that does not exist.

### Residuals found during verification

`internal/AGENTS.md` described integration tests as testcontainers-driven with an auto-starting MailHog container. There is no testcontainers dependency; the tests are build-tagged and skip without `SMTP_HOST` — and this branch had already said so correctly elsewhere, so the file contradicted its own branch. Also sharpened newly-added text that said options are "parsed with `os.LookupEnv`": environment variables supply `flag.FlagSet` defaults, so a passed CLI flag overrides the environment.

## Testing

### Test Cases

- [x] Documentation-only; no Go source changed. `go build ./...`, `go vet ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all green.
- [x] Every corrected claim was re-derived from the code or from a command run, not from another document — including `docker compose config` for the interpolation behaviour and `go test -cover ./...` for the coverage figures.
- [ ] Manual testing — not applicable.

### Known residuals, deliberately not fixed here

Pre-existing and out of scope: `docs/development-guide.md` states a 70% coverage target while `.github/codecov.yml` enforces 80% and `internal/AGENTS.md` says ≥80%; and `README.md` describes only the per-identifier reset limiter without mentioning the per-IP one.

## Deployment Notes

None. Documentation only.

---

https://claude.ai/code/session_015JAZYAZ9LgWdjrcU9sBFqM
