### PR TITLE
fix(static): correct the tile asset path and colour in browserconfig.xml

### DIFF
--- a/internal/web/static/browserconfig.xml
+++ b/internal/web/static/browserconfig.xml
@@ -2,8 +2,8 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
+            <square150x150logo src="/static/mstile-150x150.png"/>
+            <TileColor>#b8e9f4</TileColor>
         </tile>
     </msapplication>
 </browserconfig>


### PR DESCRIPTION
Two stale values in `internal/web/static/browserconfig.xml`, both leftovers from the favicon generator that produced these files.

## The asset path

```diff
-<square150x150logo src="/mstile-150x150.png"/>
+<square150x150logo src="/static/mstile-150x150.png"/>
```

Static assets are served only under the `/static` prefix — `app.Use("/static", ...)` in `main.go` is the sole static mount — so the path resolved to nothing. Every other asset reference, in the templates and in `site.webmanifest`, already carries the prefix; this file was the only one that did not.

## The tile colour

```diff
-<TileColor>#da532c</TileColor>
+<TileColor>#b8e9f4</TileColor>
```

`browserconfig.xml` declared `#da532c` (orange) while `molecules/html-head.html` sets `msapplication-TileColor` to `#b8e9f4`. Two sources described different tiles; `#b8e9f4` is the value the rest of the application uses.

## What this does not fix

`browserconfig.xml` is **not referenced by any template** — there is no `msapplication-config` meta tag — and Windows only probes it at the site root, which this app does not serve. The file therefore remains unreachable in practice. This change makes its contents correct rather than making it take effect.

Wiring it up would mean adding a meta tag for a format that only IE11 and Edge Legacy consume, both end-of-life; deleting the file is arguably the better follow-up. That is a separate decision, so this PR does neither. The file stays overridable through `BRANDING_DIR` (see #639), so a deployment that does wire it up now gets consistent values.
