### PR TITLE
chore(docs): drop the sunset Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Self-service password **change & reset** for **Active Directory and LDAP** — w
 [![CodeQL](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/codeql.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/codeql.yml)
 [![Template Drift](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml/badge.svg)](https://github.com/netresearch/ldap-selfservice-password-changer/actions/workflows/check-template-drift.yml)
 [![codecov](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer/branch/main/graph/badge.svg)](https://codecov.io/gh/netresearch/ldap-selfservice-password-changer)
-[![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ldap-selfservice-password-changer)](https://goreportcard.com/report/github.com/netresearch/ldap-selfservice-password-changer)
 [![managed by netresearch/.github templates](https://img.shields.io/badge/template-netresearch%2F.github-2F99A4?logo=github)](https://github.com/netresearch/.github/tree/main/templates/go-app)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![WCAG 2.2 AAA](https://img.shields.io/badge/WCAG%202.2-AAA%20Compliant-brightgreen?style=flat-square)](https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize&levels=aaa)


### PR DESCRIPTION
Go Report Card has been sunset — goreportcard.com now serves a farewell page:

> After more than a decade of serving the ecosystem, Go Report Card has been sunset.

The badge therefore renders against a dead service and its link leads nowhere useful. Removing it.

Only the badge lines are touched; no other README content changes. Linting coverage is unaffected — `golangci-lint` runs in CI and is what the badge was a proxy for anyway.
