### PR TITLE
fix(options): reject numeric settings that overflow their target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Out-of-range numeric settings are rejected at startup instead of wrapping.** `SMTP_PORT`, `RESET_TOKEN_EXPIRY_MINUTES`, `RESET_RATE_LIMIT_WINDOW_MINUTES` and `RESET_RATE_LIMIT_REQUESTS` are parsed as `uint` over the full 64-bit range but converted to `int` / `time.Duration` afterwards. A value above that target range wrapped: a window of `18446744073709551615` minutes became `-1m`, which makes the sliding-window limiter drop every timestamp and let every request through, and a request count that large became `-1`, which blocks all of them. Both are now config errors, as is an `SMTP_PORT` above 65535.
+
 ---
 
 ## [v1.5.0] - 2026-07-23

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/netresearch/ldap-selfservice-password-changer
 
 go 1.26
 
+// 1.26.5 carries the fixes for the standard library advisories govulncheck
+// reports against 1.26.1 (crypto/x509, html/template and others).
+toolchain go1.26.5
+
 require (
 	github.com/gofiber/fiber/v3 v3.4.0
 	github.com/joho/godotenv v1.5.1

--- a/internal/options/app.go
+++ b/internal/options/app.go
@@ -5,10 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"net/textproto"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 	ldap "github.com/netresearch/simple-ldap-go"
@@ -139,6 +141,30 @@ func envIntOrDefault(name string, d uint64, errs *ConfigError) uint {
 	}
 
 	return uint(v)
+}
+
+// Upper bounds for the numeric settings. They are parsed as uint but converted
+// downstream — the SMTP port and the request count to int, the minute values to
+// a time.Duration. strconv.ParseUint and flag.Uint both accept the full uint
+// range, so without these bounds such a value would wrap silently into a
+// negative int (a rate limiter that blocks everything) or a negative duration
+// (a window that expires before it begins, a reset token that never expires).
+const (
+	// maxSMTPPort is the highest valid TCP port number.
+	maxSMTPPort = 65535
+	// maxDurationMinutes is the largest minute count that still fits into a
+	// time.Duration, which counts nanoseconds in an int64: about 292 years.
+	maxDurationMinutes = uint64(math.MaxInt64 / int64(time.Minute))
+	// maxRateLimitRequests is the largest request count representable as an int.
+	maxRateLimitRequests = uint64(math.MaxInt)
+)
+
+// checkUintMax records a config error when value exceeds max. name is the
+// command-line flag the value came from.
+func checkUintMax(name string, value uint, maxValue uint64, errs *ConfigError) {
+	if uint64(value) > maxValue {
+		errs.Add(fmt.Sprintf("invalid value for %s: %d exceeds the maximum of %d", name, value, maxValue))
+	}
 }
 
 func envBoolOrDefault(name string, d bool, errs *ConfigError) bool {
@@ -412,6 +438,12 @@ func ParseArgs(args []string) (*Opts, error) {
 	if err := fs.Parse(args); err != nil {
 		errs.Add(fmt.Sprintf("flag parsing error: %v", err))
 	}
+
+	// Keep the conversions at the use sites total: see the bound constants.
+	checkUintMax("smtp-port", *fSMTPPort, maxSMTPPort, errs)
+	checkUintMax("reset-token-expiry-minutes", *fResetTokenExpiryMinutes, maxDurationMinutes, errs)
+	checkUintMax("reset-rate-limit-window-minutes", *fResetRateLimitWindowMinutes, maxDurationMinutes, errs)
+	checkUintMax("reset-rate-limit-requests", *fResetRateLimitRequests, maxRateLimitRequests, errs)
 
 	// Normalize and validate the password reset identifier mode
 	resetIdentifierMode := ResetIdentifierMode(strings.ToLower(strings.TrimSpace(*fResetIdentifierMode)))

--- a/internal/options/app_test.go
+++ b/internal/options/app_test.go
@@ -3,6 +3,7 @@ package options
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -890,4 +891,54 @@ func TestParseArgs_SMTPFromAddress(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, opts.SMTPFromAddress)
 	})
+}
+
+// TestParseArgs_NumericBoundsRejectOverflow covers the settings that are
+// converted to an int or a time.Duration downstream. A value that does not fit
+// the target type must be a config error instead of silently wrapping into a
+// negative rate limit or token validity.
+func TestParseArgs_NumericBoundsRejectOverflow(t *testing.T) {
+	overflowMinutes := strconv.FormatUint(maxDurationMinutes+1, 10)
+
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+	}{
+		{"smtp port", "--smtp-port", strconv.FormatUint(maxSMTPPort+1, 10)},
+		{"token expiry", "--reset-token-expiry-minutes", overflowMinutes},
+		{"rate limit window", "--reset-rate-limit-window-minutes", overflowMinutes},
+		{"rate limit requests", "--reset-rate-limit-requests", strconv.FormatUint(maxRateLimitRequests+1, 10)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			_, err := ParseArgs(append(requiredArgs(), tt.flag, tt.value))
+			require.Error(t, err)
+
+			configErr, ok := errors.AsType[*ConfigError](err)
+			require.True(t, ok, "error should be *ConfigError")
+			assert.Contains(t, configErr.Error(), strings.TrimPrefix(tt.flag, "--"))
+		})
+	}
+}
+
+// TestParseArgs_NumericBoundsAcceptMaximum verifies the bounds are inclusive,
+// so the largest representable configuration still boots.
+func TestParseArgs_NumericBoundsAcceptMaximum(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	opts, err := ParseArgs(append(requiredArgs(),
+		"--smtp-port", strconv.FormatUint(maxSMTPPort, 10),
+		"--reset-token-expiry-minutes", strconv.FormatUint(maxDurationMinutes, 10),
+		"--reset-rate-limit-window-minutes", strconv.FormatUint(maxDurationMinutes, 10),
+		"--reset-rate-limit-requests", strconv.FormatUint(maxRateLimitRequests, 10),
+	))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(maxSMTPPort), uint64(opts.SMTPPort))
+	assert.Equal(t, maxDurationMinutes, uint64(opts.ResetTokenExpiryMinutes))
+	assert.Equal(t, maxDurationMinutes, uint64(opts.ResetRateLimitWindowMinutes))
+	assert.Equal(t, maxRateLimitRequests, uint64(opts.ResetRateLimitRequests))
 }

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -141,9 +141,10 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 
 	// Create token metadata
 	now := time.Now()
-	// Safe conversion: ResetTokenExpiryMinutes is uint, typically small value (15-60)
-	// Convert to time.Duration for expiration calculation
-	//nolint:gosec // G115: small config value, safe for int64
+	// options.ParseArgs bounds the expiry to the minutes that still fit into a
+	// time.Duration, so the conversion cannot wrap into a negative (already
+	// expired) or arbitrarily large (never expiring) validity.
+	// #nosec G115 -- ParseArgs bounds this to maxDurationMinutes
 	expiryDuration := time.Duration(h.opts.ResetTokenExpiryMinutes) * time.Minute
 	token := &resettoken.ResetToken{
 		Token:            tokenString,

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func isLDAPEncrypted(server string) bool {
 // buildEmailConfig constructs an email.Config from application options.
 // Extracted for testability.
 func buildEmailConfig(opts *options.Opts) email.Config {
-	// Safe conversion: SMTPPort is uint, typically 25/587/465 (well within int range)
-	smtpPort := int(opts.SMTPPort) //#nosec G115 -- SMTPPort is 0-65535, safe for int
+	// options.ParseArgs rejects a port above 65535, so this fits in an int.
+	smtpPort := int(opts.SMTPPort) // #nosec G115 -- ParseArgs bounds this to maxSMTPPort
 	return email.Config{
 		SMTPHost:         opts.SMTPHost,
 		SMTPPort:         smtpPort,
@@ -87,10 +87,9 @@ func buildEmailConfig(opts *options.Opts) email.Config {
 // resetRateLimitSettings extracts rate limiting settings safely from options.
 // Returns request count and the window duration.
 func resetRateLimitSettings(opts *options.Opts) (int, time.Duration) {
-	// Safe conversion: ResetRateLimitRequests is uint, typically small value (3-10)
-	resetRequests := int(opts.ResetRateLimitRequests) //#nosec G115 -- small config value, safe for int
-	// Safe conversion: ResetRateLimitWindowMinutes is uint, typically 60-120
-	//#nosec G115 -- small config value, safe for int64
+	// Both values are bounded by options.ParseArgs, so neither conversion wraps.
+	resetRequests := int(opts.ResetRateLimitRequests) // #nosec G115 -- ParseArgs bounds this to math.MaxInt
+	// #nosec G115 -- ParseArgs bounds this to maxDurationMinutes
 	resetWindowDuration := time.Duration(opts.ResetRateLimitWindowMinutes) * time.Minute
 	return resetRequests, resetWindowDuration
 }


### PR DESCRIPTION
## Description

`gosec ./...` reported four G115 findings (integer overflow conversion `uint` -> `int` / `int64`): `main.go:69`, `main.go:91`, `main.go:94` and `internal/rpchandler/request_password_reset.go:147`. Three of them already carried a `#nosec` annotation claiming the value was safe. **All four are real.** Nothing bounded the source values, so the annotations asserted a range that was never checked.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] 💥 Breaking change

## Per finding

| Site | Verdict | Why |
| --- | --- | --- |
| `main.go:69` — `int(opts.SMTPPort)` | real | Annotation said "SMTPPort is 0-65535". Nothing enforced that: `envIntOrDefault` parses with `strconv.ParseUint(raw, 10, strconv.IntSize)` and `flag.Uint` accepts the same range, so `SMTP_PORT` could be any value up to 2^64-1. |
| `main.go:91` — `int(opts.ResetRateLimitRequests)` | real | Same unbounded source. `RESET_RATE_LIMIT_REQUESTS=18446744073709551615` converts to `-1`; `Limiter.AllowRequest` compares `len(timestamps) >= maxRequests`, so every request is rejected. |
| `main.go:94` — `time.Duration(opts.ResetRateLimitWindowMinutes) * time.Minute` | real | `time.Duration` counts nanoseconds in an `int64`, so the product wraps above 153722867 minutes. A negative window puts `cutoff := now.Add(-l.window)` in the future, `slices.DeleteFunc` then drops every recorded timestamp on each call and the limiter stops limiting. |
| `internal/rpchandler/request_password_reset.go:147` — `time.Duration(h.opts.ResetTokenExpiryMinutes) * time.Minute` | real | Same wrap. Depending on the value the reset token is born already expired or valid for centuries. This one was also the only finding standalone `gosec` still reported, because the annotation was `//nolint:gosec`, which only golangci-lint honours. |

No false positives among the four.

Demonstration of the wrap with the values `ParseArgs` accepted before this PR:

```
minutes=18446744073709551615 -> duration=-1m0s ; requests=18446744073709551615 -> int=-1
minutes=153722868            -> duration=-2562047h46m33.709551616s
```

## Changes made

`options.ParseArgs` now bounds each of the four settings right after flag parsing, so the conversions at the use sites are total: the SMTP port to 65535, the two minute values to `math.MaxInt64 / int64(time.Minute)` (the largest minute count a `time.Duration` can hold, ~292 years), the request count to `math.MaxInt`. An out-of-range value is a `ConfigError` like every other invalid setting, i.e. the process refuses to start instead of running with a wrapped one. The bounds are the representability limits rather than a policy — nothing that previously produced a meaningful configuration is rejected.

The `#nosec` annotations now name the enforced bound instead of asserting an unchecked range, and the ineffective `//nolint:gosec` in `request_password_reset.go` became a `#nosec` directive, which both `gosec` and golangci-lint honour. Stacking both would have left an unused `nolint` for `nolintlint` to flag.

`go.mod` pins `toolchain go1.26.5`: `govulncheck` reported 15 standard library advisories against the 1.26.1 toolchain (crypto/x509, html/template and others), all fixed in 1.26.2 or later.

## Testing

`TestParseArgs_NumericBoundsRejectOverflow` asserts each of the four settings is refused one step above its bound, `TestParseArgs_NumericBoundsAcceptMaximum` asserts the bounds are inclusive so the largest representable configuration still boots.

```
$ go build ./... && go vet ./...
$ go test ./... -count=1
ok  	github.com/netresearch/ldap-selfservice-password-changer	0.975s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/email	0.015s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/options	0.018s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/ratelimit	0.004s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/resettoken	0.078s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/rpchandler	20.923s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/validators	0.002s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/web/static	0.018s
ok  	github.com/netresearch/ldap-selfservice-password-changer/internal/web/templates	0.032s

$ go run github.com/securego/gosec/v2/cmd/gosec@latest ./...
  Files  : 24
  Lines  : 3578
  Nosec  : 4
  Issues : 0
(exit 0)

$ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
(exit 0)

$ golangci-lint run ./...
0 issues.
```

## Deployment notes

- [x] Backward compatible for every configuration that was not already wrapping
- [x] No configuration changes required

A deployment that set one of the four variables above its bound previously booted and behaved incorrectly (no rate limiting, or all requests blocked); it will now fail to start with a message naming the setting and the maximum.

## Known limitations

`gosec -tests ./...` reports seven further findings in `_test.go` files (six G101 hardcoded-credential hits on test fixtures, one G302 on a `t.Cleanup` `os.Chmod(dir, 0o700)`). They predate this branch, are excluded by the repo's golangci-lint config, and are untouched here.
