### PR TITLE
Add Cloudflare Turnstile support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -35,6 +35,14 @@
 # value.
 # RESET_IDENTIFIER_MODE=email
 
+# --- Cloudflare Turnstile -----------------------------------------------
+# Optional bot protection. Disabled by default.
+# When enabled, both the site key and secret are required.
+# CF_TURNSTILE_ENABLED=false
+# CF_TURNSTILE_SITE_KEY=
+# CF_TURNSTILE_SECRET=
+# CF_TURNSTILE_TIMEOUT_SECONDS=5
+
 # --- Branding ----------------------------------------------------------
 # All optional; unset => stock appearance.
 # BRANDING_PRODUCT_NAME=Acme Passwords

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ and changing it requires a code change. Both limiters hold state in memory
 only, so a restart clears them and a multi-instance deployment limits per
 instance rather than globally.
 
+### Cloudflare Turnstile
+
+Cloudflare Turnstile can optionally protect password operations from automated requests.
+
+- `CF_TURNSTILE_ENABLED` - Enable Cloudflare Turnstile protection (default: `false`)
+- `CF_TURNSTILE_SITE_KEY` - Cloudflare Turnstile site key (required when `CF_TURNSTILE_ENABLED=true`)
+- `CF_TURNSTILE_SECRET` - Cloudflare Turnstile secret key (required when `CF_TURNSTILE_ENABLED=true`)
+- `CF_TURNSTILE_TIMEOUT_SECONDS` - Cloudflare Turnstile verification timeout in seconds (default and maximum: `5`)
+
+When Turnstile is enabled:
+
+- Startup fails if either the site key or secret key is missing.
+- The Content Security Policy permits scripts, connections, and frames from `https://challenges.cloudflare.com` so the Turnstile widget can operate.
+
+**Privacy:** Enabling Turnstile causes visitors' browsers to communicate with Cloudflare and may send visitor data to Cloudflare. Operators, particularly those running self-hosted deployments in the EU, should evaluate the applicable privacy and data-protection requirements before enabling it.
+
+Cloudflare Turnstile protection is fail-closed. When enabled, requests cannot proceed unless verification with Cloudflare succeeds. If Cloudflare's verification service is unavailable, password operations protected by Turnstile remain unavailable until the service recovers or Turnstile is disabled.
+
+Verification failures are logged server-side, including Cloudflare-provided error codes when available, while the client receives only a generic error message.
+
 ### Branding (optional)
 
 Every value is optional and the defaults reproduce the stock appearance, so an existing deployment looks unchanged after upgrading.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This application achieves **WCAG 2.2 Level AAA compliance** with adaptive features that respond to user preferences and device capabilities. This guide explains the accessibility features, compliance details, and testing procedures.
+This application targets **WCAG 2.2 Level AAA compliance** with adaptive features that respond to user preferences and device capabilities. When the optional Cloudflare Turnstile integration is enabled, its third-party challenge iframe is provided by Cloudflare and is outside the application's direct accessibility control; the AAA claim therefore applies to the application's own frontend rather than third-party Turnstile content. Turnstile-protected password operations require JavaScript to obtain the client-side verification token. This guide explains the accessibility features, compliance details, and testing procedures.
 
 ## WCAG 2.2 Compliance Summary
 
-### Level AAA Criteria Met
+### Level AAA Criteria Targeted
 
 | Criterion | Level | Description                 | Implementation                          |
 | --------- | ----- | --------------------------- | --------------------------------------- |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,8 +13,9 @@ Content-Type: application/json
 
 ```typescript
 {
-  "method": string,  // RPC method name
-  "params": string[] // Method parameters
+  "method": string,         // RPC method name
+  "params": string[],       // Method parameters
+  "turnstileToken"?: string // Cloudflare Turnstile token when Turnstile is enabled
 }
 ```
 
@@ -42,7 +43,8 @@ Changes a user's password in the LDAP/ActiveDirectory server.
     "username", // sAMAccountName
     "currentPassword", // Current password for authentication
     "newPassword" // New password to set
-  ]
+  ],
+  "turnstileToken": "<turnstile-token>" // Cloudflare Turnstile token when Turnstile is enabled
 }
 ```
 
@@ -82,6 +84,19 @@ Changes a user's password in the LDAP/ActiveDirectory server.
 - `"the new password must contain at least {N} uppercase letter(s)"`
 - `"the new password must contain at least {N} lowercase letter(s)"`
 - `"the new password must not include the username"`
+
+##### Turnstile Verification Error
+
+When Cloudflare Turnstile protection is enabled, a missing or invalid `turnstileToken`, or a failure to verify the token with Cloudflare, causes the request to fail closed.
+
+```json
+{
+  "success": false,
+  "data": ["Turnstile verification failed"]
+}
+```
+
+**HTTP Status**: 403 Forbidden
 
 ##### LDAP Errors
 
@@ -168,7 +183,8 @@ form.onsubmit = async (e) => {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       method: "change-password",
-      params: [username, oldPassword, newPassword]
+      params: [username, oldPassword, newPassword],
+      turnstileToken
     })
   });
 

--- a/internal/options/app.go
+++ b/internal/options/app.go
@@ -28,6 +28,8 @@ const (
 	ResetIdentifierUsername ResetIdentifierMode = "username"
 	// ResetIdentifierBoth accepts either an email address or a username in one field.
 	ResetIdentifierBoth ResetIdentifierMode = "both"
+	// maxCfTurnstileTimeoutSeconds limits Turnstile verification to stay within the server write timeout.
+	maxCfTurnstileTimeoutSeconds = 5
 )
 
 // Valid reports whether the mode is a recognized value.
@@ -81,6 +83,11 @@ type Opts struct {
 	// If not set, falls back to ReadonlyUser for backward compatibility
 	ResetUser     string
 	ResetPassword string
+
+	CfTurnstileEnabled bool
+	CfTurnstileSiteKey string
+	CfTurnstileSecret  string
+	CfTurnstileTimeout time.Duration
 }
 
 // ConfigError represents a configuration validation error.
@@ -432,6 +439,27 @@ func ParseArgs(args []string) (*Opts, error) {
 			envStringOrDefault("LDAP_RESET_PASSWORD", ""),
 			"Password for the dedicated reset user.",
 		)
+
+		fCfTurnstileEnabled = fs.Bool(
+			"cf-turnstile-enabled",
+			envBoolOrDefault("CF_TURNSTILE_ENABLED", false, errs),
+			"Enable Cloudflare Turnstile bot protection.",
+		)
+		fCfTurnstileSiteKey = fs.String(
+			"cf-turnstile-site-key",
+			envStringOrDefault("CF_TURNSTILE_SITE_KEY", ""),
+			"Cloudflare Turnstile site key.",
+		)
+		fCfTurnstileSecret = fs.String(
+			"cf-turnstile-secret",
+			envStringOrDefault("CF_TURNSTILE_SECRET", ""),
+			"Cloudflare Turnstile secret key.",
+		)
+		fCfTurnstileTimeoutSeconds = fs.Uint(
+			"cf-turnstile-timeout-seconds",
+			envIntOrDefault("CF_TURNSTILE_TIMEOUT_SECONDS", 5, errs),
+			"Timeout in seconds for Cloudflare Turnstile verification.",
+		)
 	)
 
 	// Parse the provided command-line arguments (caller passes args without program name)
@@ -439,11 +467,20 @@ func ParseArgs(args []string) (*Opts, error) {
 		errs.Add(fmt.Sprintf("flag parsing error: %v", err))
 	}
 
+	validateCfTurnstileConfig(
+		*fCfTurnstileEnabled,
+		*fCfTurnstileSiteKey,
+		*fCfTurnstileSecret,
+		*fCfTurnstileTimeoutSeconds,
+		errs,
+	)
+
 	// Keep the conversions at the use sites total: see the bound constants.
 	checkUintMax("smtp-port", *fSMTPPort, maxSMTPPort, errs)
 	checkUintMax("reset-token-expiry-minutes", *fResetTokenExpiryMinutes, maxDurationMinutes, errs)
 	checkUintMax("reset-rate-limit-window-minutes", *fResetRateLimitWindowMinutes, maxDurationMinutes, errs)
 	checkUintMax("reset-rate-limit-requests", *fResetRateLimitRequests, maxRateLimitRequests, errs)
+	checkUintMax("cf-turnstile-timeout-seconds", *fCfTurnstileTimeoutSeconds, maxCfTurnstileTimeoutSeconds, errs)
 
 	// Normalize and validate the password reset identifier mode
 	resetIdentifierMode := ResetIdentifierMode(strings.ToLower(strings.TrimSpace(*fResetIdentifierMode)))
@@ -512,6 +549,11 @@ func ParseArgs(args []string) (*Opts, error) {
 		return nil, errs
 	}
 
+	cfTurnstileTimeout, err := uintSecondsToDuration(*fCfTurnstileTimeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Opts{
 		Port: *fPort,
 		LDAP: ldap.Config{
@@ -551,6 +593,11 @@ func ParseArgs(args []string) (*Opts, error) {
 
 		ResetUser:     *fResetUser,
 		ResetPassword: *fResetPassword,
+
+		CfTurnstileEnabled: *fCfTurnstileEnabled,
+		CfTurnstileSiteKey: *fCfTurnstileSiteKey,
+		CfTurnstileSecret:  *fCfTurnstileSecret,
+		CfTurnstileTimeout: cfTurnstileTimeout,
 	}, nil
 }
 
@@ -566,4 +613,32 @@ func MustParse() *Opts {
 		os.Exit(1)
 	}
 	return opts
+}
+
+func uintSecondsToDuration(value uint) (time.Duration, error) {
+	if uint64(value) > uint64(math.MaxInt64/int64(time.Second)) {
+		return 0, fmt.Errorf("seconds value %d overflows time.Duration", value)
+	}
+
+	return time.Duration(int64(value)) * time.Second, nil
+}
+
+func validateCfTurnstileConfig(
+	enabled bool,
+	siteKey, secret string,
+	timeoutSeconds uint,
+	errs *ConfigError,
+) {
+	if enabled {
+		if siteKey == "" {
+			errs.Add("cf-turnstile-site-key is required when cf-turnstile-enabled is true")
+		}
+		if secret == "" {
+			errs.Add("cf-turnstile-secret is required when cf-turnstile-enabled is true")
+		}
+	}
+
+	if timeoutSeconds == 0 {
+		errs.Add("cf-turnstile-timeout-seconds must be greater than zero")
+	}
 }

--- a/internal/options/app_test.go
+++ b/internal/options/app_test.go
@@ -697,6 +697,55 @@ func requiredArgs() []string {
 	}
 }
 
+func TestParseArgs_CloudflareTurnstileValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "enabled without site key",
+			args: []string{
+				"--cf-turnstile-enabled",
+				"--cf-turnstile-secret", "secret",
+			},
+			want: "cf-turnstile-site-key is required",
+		},
+		{
+			name: "enabled without secret",
+			args: []string{
+				"--cf-turnstile-enabled",
+				"--cf-turnstile-site-key", "site-key",
+			},
+			want: "cf-turnstile-secret is required",
+		},
+		{
+			name: "zero timeout",
+			args: []string{
+				"--cf-turnstile-timeout-seconds", "0",
+			},
+			want: "cf-turnstile-timeout-seconds must be greater than zero",
+		},
+		{
+			name: "timeout above maximum",
+			args: []string{
+				"--cf-turnstile-timeout-seconds", "6",
+			},
+			want: "cf-turnstile-timeout-seconds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			_, err := ParseArgs(append(requiredArgs(), tt.args...))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
 func TestParseArgs_EmailTemplateOptions(t *testing.T) {
 	// Run from a temp dir so no .env is loaded from the repo.
 	t.Chdir(t.TempDir())

--- a/internal/rpchandler/change_password.go
+++ b/internal/rpchandler/change_password.go
@@ -10,7 +10,7 @@ import (
 const msgPasswordChanged = "password changed successfully"
 
 // changePasswordWithIP handles password change requests with IP-based rate limiting.
-func (c *Handler) changePasswordWithIP(params []string, clientIP string) ([]string, error) {
+func (c *Handler) changePasswordWithIP(params []string, clientIP, turnstileToken string) ([]string, error) {
 	if len(params) != 3 {
 		return nil, ErrInvalidArgumentCount
 	}
@@ -23,6 +23,10 @@ func (c *Handler) changePasswordWithIP(params []string, clientIP string) ([]stri
 	if c.ipLimiter != nil && !c.ipLimiter.AllowRequest(clientIP) {
 		slog.Warn("password_change_ip_rate_limited", "ip", clientIP, "username", sAMAccountName)
 		return nil, errors.New("too many password change attempts from your IP address, please try again later")
+	}
+
+	if err := c.verifyTurnstile(turnstileToken, clientIP); err != nil {
+		return nil, err
 	}
 
 	if sAMAccountName == "" {

--- a/internal/rpchandler/change_password_internal_test.go
+++ b/internal/rpchandler/change_password_internal_test.go
@@ -244,6 +244,7 @@ func TestChangePasswordIPRateLimiting(t *testing.T) {
 		result, err := handler.changePasswordWithIP(
 			[]string{"testuser", "OldPass123!", "NewPass456!"},
 			clientIP,
+			"",
 		)
 		if err != nil {
 			t.Fatalf("Request %d failed: %v", i, err)
@@ -259,6 +260,7 @@ func TestChangePasswordIPRateLimiting(t *testing.T) {
 	result, err := handler.changePasswordWithIP(
 		[]string{"testuser", "OldPass123!", "NewPass456!"},
 		clientIP,
+		"",
 	)
 
 	if err == nil {
@@ -344,7 +346,7 @@ func TestChangePasswordEmptyInputs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := handler.changePasswordWithIP(tt.params, testClientIP)
+			result, err := handler.changePasswordWithIP(tt.params, testClientIP, "")
 			if err == nil {
 				t.Errorf("Expected error containing %q, got nil", tt.wantError)
 				return
@@ -380,6 +382,7 @@ func TestChangePasswordSamePassword(t *testing.T) {
 	result, err := handler.changePasswordWithIP(
 		[]string{"testuser", "SamePass123!", "SamePass123!"},
 		testClientIP,
+		"",
 	)
 
 	if err == nil {
@@ -417,6 +420,7 @@ func TestChangePasswordLDAPError(t *testing.T) {
 	result, err := handler.changePasswordWithIP(
 		[]string{"testuser", "OldPass123!", "NewPass456!"},
 		testClientIP,
+		"",
 	)
 
 	if err == nil {
@@ -455,7 +459,7 @@ func TestChangePasswordInvalidArgumentCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := handler.changePasswordWithIP(tt.params, testClientIP)
+			_, err := handler.changePasswordWithIP(tt.params, testClientIP, "")
 			if !errors.Is(err, ErrInvalidArgumentCount) {
 				t.Errorf("Expected ErrInvalidArgumentCount, got: %v", err)
 			}
@@ -483,6 +487,7 @@ func TestChangePasswordNoIPLimiter(t *testing.T) {
 	result, err := handler.changePasswordWithIP(
 		[]string{"testuser", "OldPass123!", "NewPass456!"},
 		testClientIP,
+		"",
 	)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -543,6 +548,7 @@ func TestChangePasswordValidationFailure(t *testing.T) {
 			result, err := handler.changePasswordWithIP(
 				[]string{tt.username, "OldPass123!", tt.newPassword},
 				testClientIP,
+				"",
 			)
 			if err == nil {
 				t.Errorf("Expected error containing %q, got nil", tt.wantError)

--- a/internal/rpchandler/dto.go
+++ b/internal/rpchandler/dto.go
@@ -7,8 +7,9 @@ var ErrInvalidArgumentCount = errors.New("invalid argument count")
 
 // Request represents a JSON-RPC 2.0 request with method name and string parameters.
 type Request struct {
-	Method string   `json:"method"`
-	Params []string `json:"params"`
+	Method         string   `json:"method"`
+	Params         []string `json:"params"`
+	TurnstileToken string   `json:"turnstileToken,omitempty"`
 }
 
 // Response represents a JSON-RPC 2.0 response with success status and data payload.

--- a/internal/rpchandler/handler.go
+++ b/internal/rpchandler/handler.go
@@ -1,13 +1,16 @@
 package rpchandler
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/gofiber/fiber/v3"
 	ldap "github.com/netresearch/simple-ldap-go"
 
 	"github.com/netresearch/ldap-selfservice-password-changer/internal/options"
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/turnstile"
 )
 
 // Func is a type alias for RPC handler functions that process string parameters and return results or errors.
@@ -36,6 +39,10 @@ type Handler struct {
 type IPLimiter interface {
 	AllowRequest(ipAddress string) bool
 }
+
+const msgTurnstileVerificationFailed = "Turnstile verification failed"
+
+var errTurnstileVerification = errors.New("turnstile verification failed")
 
 // New creates a basic Handler for password change operations without password reset services.
 func New(opts *options.Opts) (*Handler, error) {
@@ -103,19 +110,22 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 
 	switch body.Method {
 	case "change-password":
-		return h.handleChangePassword(c, body.Params, clientIP)
+		return h.handleChangePassword(c, body.Params, clientIP, body.TurnstileToken)
 	case "request-password-reset":
-		return h.handleRequestPasswordReset(c, body.Params, clientIP)
+		return h.handleRequestPasswordReset(c, body.Params, clientIP, body.TurnstileToken)
 	case "reset-password":
-		return h.handleResetPassword(c, body.Params)
+		return h.handleResetPassword(c, body.Params, clientIP, body.TurnstileToken)
 	default:
 		return sendErrorResponse(c, http.StatusBadRequest, "method not found")
 	}
 }
 
 // handleChangePassword processes change-password requests with IP-based rate limiting.
-func (h *Handler) handleChangePassword(c fiber.Ctx, params []string, clientIP string) error {
-	data, err := h.changePasswordWithIP(params, clientIP)
+func (h *Handler) handleChangePassword(c fiber.Ctx, params []string, clientIP, turnstileToken string) error {
+	data, err := h.changePasswordWithIP(params, clientIP, turnstileToken)
+	if errors.Is(err, errTurnstileVerification) {
+		return sendErrorResponse(c, http.StatusForbidden, msgTurnstileVerificationFailed)
+	}
 	if err != nil {
 		return sendErrorResponse(c, http.StatusInternalServerError, err.Error())
 	}
@@ -123,11 +133,14 @@ func (h *Handler) handleChangePassword(c fiber.Ctx, params []string, clientIP st
 }
 
 // handleRequestPasswordReset processes request-password-reset requests with IP-based rate limiting.
-func (h *Handler) handleRequestPasswordReset(c fiber.Ctx, params []string, clientIP string) error {
+func (h *Handler) handleRequestPasswordReset(c fiber.Ctx, params []string, clientIP, turnstileToken string) error {
 	if h.tokenStore == nil {
 		return sendErrorResponse(c, http.StatusBadRequest, "password reset feature not enabled")
 	}
-	data, err := h.requestPasswordResetWithIP(params, clientIP)
+	data, err := h.requestPasswordResetWithIP(params, clientIP, turnstileToken)
+	if errors.Is(err, errTurnstileVerification) {
+		return sendErrorResponse(c, http.StatusForbidden, msgTurnstileVerificationFailed)
+	}
 	if err != nil {
 		return sendErrorResponse(c, http.StatusInternalServerError, err.Error())
 	}
@@ -135,9 +148,19 @@ func (h *Handler) handleRequestPasswordReset(c fiber.Ctx, params []string, clien
 }
 
 // handleResetPassword processes reset-password requests.
-func (h *Handler) handleResetPassword(c fiber.Ctx, params []string) error {
+func (h *Handler) handleResetPassword(c fiber.Ctx, params []string, clientIP, turnstileToken string) error {
 	if h.tokenStore == nil {
 		return sendErrorResponse(c, http.StatusBadRequest, "password reset feature not enabled")
+	}
+	if h.ipLimiter != nil && !h.ipLimiter.AllowRequest(clientIP) {
+		return sendErrorResponse(
+			c,
+			http.StatusTooManyRequests,
+			"too many password reset attempts from your IP address, please try again later",
+		)
+	}
+	if err := h.verifyTurnstile(turnstileToken, clientIP); err != nil {
+		return sendErrorResponse(c, http.StatusForbidden, msgTurnstileVerificationFailed)
 	}
 	data, err := h.resetPassword(params)
 	if err != nil {
@@ -165,5 +188,25 @@ func sendErrorResponse(c fiber.Ctx, statusCode int, message string) error {
 	}); jsonErr != nil {
 		return fmt.Errorf("failed to send error response: %w", jsonErr)
 	}
+	return nil
+}
+
+// verifyTurnstile verifies the provided Turnstile token when Cloudflare
+// Turnstile protection is enabled.
+func (h *Handler) verifyTurnstile(token, clientIP string) error {
+	if !h.opts.CfTurnstileEnabled {
+		return nil
+	}
+
+	if err := turnstile.Verify(
+		h.opts.CfTurnstileSecret,
+		token,
+		clientIP,
+		h.opts.CfTurnstileTimeout,
+	); err != nil {
+		slog.Warn("turnstile_verification_failed", "ip", clientIP, "error", err)
+		return errTurnstileVerification
+	}
+
 	return nil
 }

--- a/internal/rpchandler/handler_internal_test.go
+++ b/internal/rpchandler/handler_internal_test.go
@@ -526,6 +526,41 @@ func TestHandleResetPasswordSuccess(t *testing.T) {
 	}
 }
 
+// TestHandleResetPasswordIPRateLimitBeforeTurnstile verifies that IP rate
+// limiting rejects reset-password requests before Turnstile verification.
+func TestHandleResetPasswordIPRateLimitBeforeTurnstile(t *testing.T) {
+	handler := createTestHandlerWithResetEnabled()
+	handler.opts.CfTurnstileEnabled = true
+
+	handler.ipLimiter = &mockHandlerIPLimiter{allowed: false}
+
+	app := fiber.New()
+	app.Post("/api/rpc", handler.Handle)
+
+	body := `{"method":"reset-password","params":["validtoken","NewPass123!"]}`
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/rpc",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf(
+			"status = %d, want %d",
+			resp.StatusCode,
+			http.StatusTooManyRequests,
+		)
+	}
+}
+
 // TestHandleChangePasswordSuccess tests successful password change with full response validation.
 func TestHandleChangePasswordSuccess(t *testing.T) {
 	handler := createTestHandler()
@@ -677,4 +712,101 @@ func (m *mockHandlerTokenStoreWithToken) CleanupExpired() int {
 
 func (m *mockHandlerTokenStoreWithToken) Count() int {
 	return 1
+}
+
+// TestHandleTurnstileMissingToken verifies that all protected RPC methods
+// return HTTP 403 when Turnstile is enabled and the token is missing.
+func TestHandleTurnstileMissingToken(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "change-password",
+			body: `{"method":"change-password","params":["testuser","OldPass123!","NewPass456!"]}`,
+		},
+		{
+			name: "request-password-reset",
+			body: `{"method":"request-password-reset","params":["user@example.com"]}`,
+		},
+		{
+			name: "reset-password",
+			body: `{"method":"reset-password","params":["validtoken","NewPass123!"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := createTestHandlerWithResetEnabled()
+			handler.opts.CfTurnstileEnabled = true
+
+			app := fiber.New()
+			app.Post("/api/rpc", handler.Handle)
+
+			req := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
+				"/api/rpc",
+				strings.NewReader(tt.body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("app.Test failed: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusForbidden {
+				bodyBytes, readErr := io.ReadAll(resp.Body)
+				if readErr != nil {
+					t.Fatalf("failed to read response body: %v", readErr)
+				}
+				t.Errorf(
+					"status = %d, want %d (body: %s)",
+					resp.StatusCode,
+					http.StatusForbidden,
+					string(bodyBytes),
+				)
+			}
+		})
+	}
+}
+
+// TestHandleTurnstileDisabledPassthrough verifies that requests without a
+// Turnstile token are allowed through when Turnstile protection is disabled.
+func TestHandleTurnstileDisabledPassthrough(t *testing.T) {
+	handler := createTestHandler()
+	handler.opts.CfTurnstileEnabled = false
+
+	app := fiber.New()
+	app.Post("/api/rpc", handler.Handle)
+
+	body := `{"method":"change-password","params":["testuser","OldPass123!","NewPass456!"]}`
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/rpc",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			t.Fatalf("failed to read response body: %v", readErr)
+		}
+		t.Errorf(
+			"status = %d, want %d (body: %s)",
+			resp.StatusCode,
+			http.StatusOK,
+			string(bodyBytes),
+		)
+	}
 }

--- a/internal/rpchandler/request_password_reset.go
+++ b/internal/rpchandler/request_password_reset.go
@@ -49,12 +49,43 @@ type TokenStore interface {
 func (h *Handler) requestPasswordReset(params []string) ([]string, error) {
 	// For backward compatibility, call the IP-aware version with a placeholder IP
 	// In production, this should not be called - Handle() uses requestPasswordResetWithIP
-	return h.requestPasswordResetWithIP(params, "0.0.0.0")
+	return h.requestPasswordResetWithIP(params, "0.0.0.0", "")
+}
+
+// allowPasswordResetRequest applies IP rate limiting and Turnstile verification
+// before a password reset request is processed.
+func (h *Handler) allowPasswordResetRequest(clientIP, emailOrUsername, turnstileToken string) (bool, error) {
+	// FIRST: Check IP-based rate limit (stricter, catches flooding)
+	// This prevents attackers from using different emails to bypass rate limiting
+	if h.ipLimiter != nil && !h.ipLimiter.AllowRequest(clientIP) {
+		// IP is rate limited - return success but don't proceed
+		slog.Warn("password_reset_ip_rate_limited", "ip", clientIP)
+		return false, nil
+	}
+
+	// SECOND: Check the rate limit for the typed identifier (per-user
+	// protection). The "typed:" prefix keeps these buckets disjoint from the
+	// post-resolution "account:" buckets below — without it, an attacker could
+	// pre-exhaust a victim's account bucket by literally typing
+	// "account:<username>" into the form.
+	if !h.rateLimiter.AllowRequest("typed:" + emailOrUsername) {
+		// User is rate limited - return success but don't proceed
+		slog.Warn("password_reset_rate_limited", "email", emailOrUsername)
+		return false, nil
+	}
+
+	// THIRD: Verify Turnstile only after local rate limiting to avoid unmetered
+	// outbound verification requests to Cloudflare.
+	if err := h.verifyTurnstile(turnstileToken, clientIP); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // requestPasswordResetWithIP handles password reset requests with IP-based rate limiting.
 // Always returns a generic success message to prevent user enumeration.
-func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) ([]string, error) {
+func (h *Handler) requestPasswordResetWithIP(params []string, clientIP, turnstileToken string) ([]string, error) {
 	// Validate parameter count
 	if len(params) != 1 {
 		return nil, ErrInvalidArgumentCount
@@ -73,22 +104,13 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 		return genericSuccess, nil
 	}
 
-	// FIRST: Check IP-based rate limit (stricter, catches flooding)
-	// This prevents attackers from using different emails to bypass rate limiting
-	if h.ipLimiter != nil && !h.ipLimiter.AllowRequest(clientIP) {
-		// IP is rate limited - return success but don't proceed
-		slog.Warn("password_reset_ip_rate_limited", "ip", clientIP)
-		return genericSuccess, nil
+	// Apply local rate limiting and Turnstile verification before performing
+	// expensive token generation or LDAP operations.
+	allowed, err := h.allowPasswordResetRequest(clientIP, emailOrUsername, turnstileToken)
+	if err != nil {
+		return nil, err
 	}
-
-	// SECOND: Check the rate limit for the typed identifier (per-user
-	// protection). The "typed:" prefix keeps these buckets disjoint from the
-	// post-resolution "account:" buckets below — without it, an attacker could
-	// pre-exhaust a victim's account bucket by literally typing
-	// "account:<username>" into the form.
-	if !h.rateLimiter.AllowRequest("typed:" + emailOrUsername) {
-		// User is rate limited - return success but don't proceed
-		slog.Warn("password_reset_rate_limited", "email", emailOrUsername)
+	if !allowed {
 		return genericSuccess, nil
 	}
 
@@ -114,7 +136,7 @@ func (h *Handler) requestPasswordResetWithIP(params []string, clientIP string) (
 
 	username := user.SAMAccountName
 
-	// THIRD: Check the rate limit for the RESOLVED account. The pre-lookup
+	// Check the rate limit for the RESOLVED account. The pre-lookup
 	// check above is keyed on the typed string, so one mailbox reachable via
 	// several identifiers (email and username in "both" mode, or an account
 	// with multiple mail values) would otherwise get one bucket per spelling,

--- a/internal/rpchandler/request_password_reset_internal_test.go
+++ b/internal/rpchandler/request_password_reset_internal_test.go
@@ -372,7 +372,7 @@ func TestRequestPasswordResetIPRateLimitingIntegration(t *testing.T) {
 	// These should all succeed (within IP rate limit)
 	for i := 1; i <= 10; i++ {
 		email := fmt.Sprintf("user%d@example.com", i)
-		result, err := handler.requestPasswordResetWithIP([]string{email}, clientIP)
+		result, err := handler.requestPasswordResetWithIP([]string{email}, clientIP, "")
 		require.NoError(t, err, "Request %d failed", i)
 		if len(result) != 1 {
 			t.Errorf("Request %d: expected 1 result, got %d", i, len(result))
@@ -385,7 +385,7 @@ func TestRequestPasswordResetIPRateLimitingIntegration(t *testing.T) {
 	}
 
 	// 11th request from same IP should be rate limited by IP limiter
-	result, err := handler.requestPasswordResetWithIP([]string{"user11@example.com"}, clientIP)
+	result, err := handler.requestPasswordResetWithIP([]string{"user11@example.com"}, clientIP, "")
 	if err != nil {
 		t.Errorf("Rate limited request should not error, got: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestRequestPasswordResetIPRateLimitCheckedBeforeEmail(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		email := fmt.Sprintf("user%d@example.com", i)
 		mockLDAP.users[email] = &ldap.User{SAMAccountName: fmt.Sprintf("user%d", i)}
-		if _, err := handler.requestPasswordResetWithIP([]string{email}, clientIP); err != nil {
+		if _, err := handler.requestPasswordResetWithIP([]string{email}, clientIP, ""); err != nil {
 			t.Fatalf("Failed to request password reset: %v", err)
 		}
 	}
@@ -442,7 +442,7 @@ func TestRequestPasswordResetIPRateLimitCheckedBeforeEmail(t *testing.T) {
 
 	initialEmailLimiterCount := emailLimiter.Count()
 
-	result, err := handler.requestPasswordResetWithIP([]string{newEmail}, clientIP)
+	result, err := handler.requestPasswordResetWithIP([]string{newEmail}, clientIP, "")
 	if err != nil {
 		t.Errorf("Should not error, got: %v", err)
 	}

--- a/internal/turnstile/turnstile.go
+++ b/internal/turnstile/turnstile.go
@@ -1,0 +1,81 @@
+// Package turnstile provides Cloudflare Turnstile token verification.
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const siteverifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+type verifyResponse struct {
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+}
+
+// Verify validates a Turnstile token with Cloudflare.
+func Verify(secret, token, remoteIP string, timeout time.Duration) error {
+	return VerifyWithEndpoint(siteverifyURL, secret, token, remoteIP, timeout)
+}
+
+// VerifyWithEndpoint validates a Turnstile token using the provided verification endpoint.
+func VerifyWithEndpoint(endpoint, secret, token, remoteIP string, timeout time.Duration) error {
+	if token == "" {
+		return errors.New("missing Turnstile token")
+	}
+
+	values := url.Values{
+		"secret":   {secret},
+		"response": {token},
+	}
+
+	if remoteIP != "" {
+		values.Set("remoteip", remoteIP)
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		endpoint,
+		strings.NewReader(values.Encode()),
+	)
+	if err != nil {
+		return fmt.Errorf("create Turnstile verification request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("verify Turnstile token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("turnstile verification returned HTTP %d", resp.StatusCode)
+	}
+
+	var result verifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode Turnstile verification response: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf(
+			"turnstile verification failed: error-codes=%v",
+			result.ErrorCodes,
+		)
+	}
+
+	return nil
+}

--- a/internal/turnstile/turnstile_test.go
+++ b/internal/turnstile/turnstile_test.go
@@ -1,0 +1,111 @@
+package turnstile_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/netresearch/ldap-selfservice-password-changer/internal/turnstile"
+)
+
+func withSiteverifyServer(t *testing.T, handler http.HandlerFunc) string {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return server.URL
+}
+
+func TestVerifySuccess(t *testing.T) {
+	endpoint := withSiteverifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf(
+				"Content-Type = %q, want %q",
+				got,
+				"application/x-www-form-urlencoded",
+			)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm() error = %v", err)
+			return
+		}
+
+		if got := r.Form.Get("secret"); got != "secret" {
+			t.Errorf("secret = %q, want %q", got, "secret")
+		}
+		if got := r.Form.Get("response"); got != "token" {
+			t.Errorf("response = %q, want %q", got, "token")
+		}
+		if got := r.Form.Get("remoteip"); got != "127.0.0.1" {
+			t.Errorf("remoteip = %q, want %q", got, "127.0.0.1")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"success":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+
+	if err := turnstile.VerifyWithEndpoint(
+		endpoint,
+		"secret",
+		"token",
+		"127.0.0.1",
+		time.Second,
+	); err != nil {
+		t.Fatalf("VerifyWithEndpoint() error = %v", err)
+	}
+}
+
+func TestVerifyFailure(t *testing.T) {
+	endpoint := withSiteverifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"success":false}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+
+	if err := turnstile.VerifyWithEndpoint(endpoint, "secret", "token", "127.0.0.1", time.Second); err == nil {
+		t.Fatal("VerifyWithEndpoint() expected error")
+	}
+}
+
+func TestVerifyNonOKStatus(t *testing.T) {
+	endpoint := withSiteverifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "error", http.StatusInternalServerError)
+	})
+
+	if err := turnstile.VerifyWithEndpoint(endpoint, "secret", "token", "127.0.0.1", time.Second); err == nil {
+		t.Fatal("VerifyWithEndpoint() expected error")
+	}
+}
+
+func TestVerifyTimeout(t *testing.T) {
+	endpoint := withSiteverifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"success":true}`)); err != nil {
+			return
+		}
+	})
+
+	if err := turnstile.VerifyWithEndpoint(endpoint, "secret", "token", "127.0.0.1", 10*time.Millisecond); err == nil {
+		t.Fatal("VerifyWithEndpoint() expected timeout error")
+	}
+}
+
+func TestVerifyMalformedJSON(t *testing.T) {
+	endpoint := withSiteverifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`not-json`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+
+	if err := turnstile.VerifyWithEndpoint(endpoint, "secret", "token", "127.0.0.1", time.Second); err == nil {
+		t.Fatal("VerifyWithEndpoint() expected error")
+	}
+}

--- a/internal/web/AGENTS.md
+++ b/internal/web/AGENTS.md
@@ -23,10 +23,10 @@ Note: HTTP handlers, middleware, and server setup are in `main.go` at the projec
 
 **Key characteristics**:
 
-- **WCAG 2.2 AAA**: 7:1 contrast, keyboard navigation, screen reader support, adaptive density
+- **WCAG 2.2 AAA target**: 7:1 contrast, keyboard navigation, screen reader support, adaptive density; third-party Turnstile content is outside this scope
 - **Ultra-strict TypeScript**: All strict flags enabled, no `any` types
 - **Tailwind CSS 4**: Utility-first, dark mode, responsive, accessible patterns
-- **Progressive enhancement**: Works without JavaScript (forms submit via HTTP)
+- **Progressive enhancement**: Works without JavaScript (forms submit via HTTP) when Cloudflare Turnstile is disabled
 - **Password manager friendly**: Proper autocomplete attributes
 
 ## Setup/Environment
@@ -323,7 +323,7 @@ console.log(items[0].toUpperCase()); // ❌ may crash if empty array
 - **Autocomplete hygiene.** New-password fields MUST set `autocomplete="new-password"`; current-password fields use `autocomplete="current-password"`. Wrong or missing autocomplete confuses password managers and can cause them to fill wrong values.
 - **Password-manager-friendly forms.** Every password input sits inside a `<form>` with proper `<label>`. Don't hide real `<input type="password">` behind a fake div — managers won't detect it.
 - **No PII in client logs.** Never `console.log` passwords, tokens, usernames, or email addresses. Strip diagnostic logs before committing.
-- **No third-party scripts.** Keep the CSP strict; no CDN-hosted libraries, no analytics, no remote fonts. All assets ship from the same origin via Go's embedded FS.
+- **No third-party scripts by default.** Keep the CSP strict; no CDN-hosted libraries, analytics, or remote fonts. The sole approved exception is the opt-in Cloudflare Turnstile integration, which loads `https://challenges.cloudflare.com/turnstile/v0/api.js` only when `CF_TURNSTILE_ENABLED` is explicitly enabled. All other assets ship from the same origin via Go's embedded FS.
 - **Focus trap on modals.** Any dialog must trap focus while open (for security + a11y). Escape must close and restore focus.
 - **Subresource integrity.** If a local asset ever must reference an external URL (shouldn't happen here), pin with SRI hashes.
 - **Tailwind classes are static.** Never template-compose class names from user data — JIT won't pick them up and the attacker could produce unexpected styling. Always full static strings.

--- a/internal/web/static/js/app.ts
+++ b/internal/web/static/js/app.ts
@@ -20,6 +20,7 @@ import {
   updateErrorSummary
 } from "./error-utils.js";
 import { renderPolicyList } from "./policy-ui.js";
+import { getTurnstileToken, isTurnstileTokenMissing, resetTurnstile, turnstileRequestFields } from "./turnstile.js";
 
 interface Opts {
   minLength: number;
@@ -223,12 +224,20 @@ export const init = (opts: Opts) => {
     const [username, oldPassword, newPassword] = fields.map((f) => f.getValue());
 
     try {
+      const turnstileToken = getTurnstileToken(form);
+      if (isTurnstileTokenMissing(form, turnstileToken)) {
+        setSubmitError(submitErrorContainer, "Please complete the verification challenge.");
+        toggleFields(true);
+        return;
+      }
+
       const res = await fetch("/api/rpc", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           method: "change-password",
-          params: [username, oldPassword, newPassword]
+          params: [username, oldPassword, newPassword],
+          ...turnstileRequestFields(turnstileToken)
         })
       });
 
@@ -248,6 +257,7 @@ export const init = (opts: Opts) => {
       successContainer.classList.remove("hidden");
     } catch (err) {
       setSubmitError(submitErrorContainer, (err as Error).message);
+      resetTurnstile(form);
       toggleFields(true);
     }
   };

--- a/internal/web/static/js/forgot-password.ts
+++ b/internal/web/static/js/forgot-password.ts
@@ -1,6 +1,7 @@
 import { mustNotBeEmpty, isValidEmail } from "./validators.js";
 import { initThemeToggle, initDensityToggle } from "./toggles.js";
 import { type FieldError, setFieldErrors, setSubmitError, updateErrorSummary } from "./error-utils.js";
+import { getTurnstileToken, isTurnstileTokenMissing, resetTurnstile, turnstileRequestFields } from "./turnstile.js";
 
 type IdentifierMode = "email" | "username" | "both";
 
@@ -146,10 +147,21 @@ export const init = (rawMode: string) => {
     const [email] = fields.map((f) => f.getValue());
 
     try {
+      const turnstileToken = getTurnstileToken(form);
+      if (isTurnstileTokenMissing(form, turnstileToken)) {
+        setSubmitError(submitErrorContainer, "Please complete the verification challenge.");
+        toggleFields(true);
+        return;
+      }
+
       const res = await fetch("/api/rpc", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ method: "request-password-reset", params: [email] })
+        body: JSON.stringify({
+          method: "request-password-reset",
+          params: [email],
+          ...turnstileRequestFields(turnstileToken)
+        })
       });
 
       const body = await res.text();
@@ -168,6 +180,7 @@ export const init = (rawMode: string) => {
       successContainer.classList.remove("hidden");
     } catch (err) {
       setSubmitError(submitErrorContainer, (err as Error).message);
+      resetTurnstile(form);
       toggleFields(true);
     }
   };

--- a/internal/web/static/js/reset-password.ts
+++ b/internal/web/static/js/reset-password.ts
@@ -17,6 +17,7 @@ import {
   updateErrorSummary
 } from "./error-utils.js";
 import { renderPolicyList } from "./policy-ui.js";
+import { getTurnstileToken, isTurnstileTokenMissing, resetTurnstile, turnstileRequestFields } from "./turnstile.js";
 
 interface Opts {
   minLength: number;
@@ -219,10 +220,21 @@ export const init = (opts: Opts) => {
     const [newPassword] = fields.map((f) => f.getValue());
 
     try {
+      const turnstileToken = getTurnstileToken(form);
+      if (isTurnstileTokenMissing(form, turnstileToken)) {
+        setSubmitError(submitErrorContainer, "Please complete the verification challenge.");
+        toggleFields(true);
+        return;
+      }
+
       const res = await fetch("/api/rpc", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ method: "reset-password", params: [token, newPassword] })
+        body: JSON.stringify({
+          method: "reset-password",
+          params: [token, newPassword],
+          ...turnstileRequestFields(turnstileToken)
+        })
       });
 
       const body = await res.text();
@@ -241,6 +253,7 @@ export const init = (opts: Opts) => {
       successContainer.classList.remove("hidden");
     } catch (err) {
       setSubmitError(submitErrorContainer, (err as Error).message);
+      resetTurnstile(form);
       toggleFields(true);
     }
   };

--- a/internal/web/static/js/turnstile.ts
+++ b/internal/web/static/js/turnstile.ts
@@ -1,0 +1,18 @@
+declare const turnstile: {
+  reset: () => void;
+};
+
+export const getTurnstileToken = (form: HTMLFormElement): string =>
+  form.querySelector<HTMLInputElement>('input[name="cf-turnstile-response"]')?.value ?? "";
+
+export const isTurnstileTokenMissing = (form: HTMLFormElement, token: string): boolean =>
+  form.querySelector(".cf-turnstile") !== null && !token;
+
+export const resetTurnstile = (form: HTMLFormElement): void => {
+  if (form.querySelector(".cf-turnstile")) {
+    turnstile.reset();
+  }
+};
+
+export const turnstileRequestFields = (token: string): { turnstileToken?: string } =>
+  token ? { turnstileToken: token } : {};

--- a/internal/web/templates/forgot-password.html
+++ b/internal/web/templates/forgot-password.html
@@ -4,6 +4,13 @@
     <title>Forgot Password — {{ .branding.Name }}</title>
     {{ template "html-head" }} {{ template "theme-init-script" }} {{ template "density-init-script" }}
     <link rel="modulepreload" href="/static/js/forgot-password.js" crossorigin="anonymous" />
+    {{ if .opts.CfTurnstileEnabled }}
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    ></script>
+    {{ end }}
   </head>
 
   <body class="page-body">
@@ -41,6 +48,10 @@
           {{ else }}
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "email" "Email Address" "email" "email" "Enter your email address to receive a password reset link" }}
+          {{ end }}
+
+          {{ if .opts.CfTurnstileEnabled }}
+          {{ template "turnstile" .opts.CfTurnstileSiteKey }}
           {{ end }}
 
           {{ template "form-submit" "Send Reset Link" }}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -4,6 +4,13 @@
     <title>{{ .branding.PageTitle }}</title>
     {{ template "html-head" }} {{ template "theme-init-script" }} {{ template "density-init-script" }}
     <link rel="modulepreload" href="/static/js/app.js" crossorigin="anonymous" />
+    {{ if .opts.CfTurnstileEnabled }}
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    ></script>
+    {{ end }}
   </head>
 
   <body class="page-body">
@@ -42,6 +49,10 @@
           ></ul>
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "confirm_password" "Confirm New Password" "password" "new-password" "Re-enter your new password to confirm" }}
+
+          {{ if .opts.CfTurnstileEnabled }}
+          {{ template "turnstile" .opts.CfTurnstileSiteKey }}
+          {{ end }}
 
           {{ template "form-submit" "Update Password" }}
         </form>

--- a/internal/web/templates/molecules/turnstile.html
+++ b/internal/web/templates/molecules/turnstile.html
@@ -1,0 +1,5 @@
+{{ define "turnstile" }}
+{{ if . }}
+<div class="cf-turnstile" data-sitekey="{{ . }}"></div>
+{{ end }}
+{{ end }}

--- a/internal/web/templates/reset-password.html
+++ b/internal/web/templates/reset-password.html
@@ -4,6 +4,13 @@
     <title>Reset Password — {{ .branding.Name }}</title>
     {{ template "html-head" }} {{ template "theme-init-script" }} {{ template "density-init-script" }}
     <link rel="modulepreload" href="/static/js/reset-password.js" crossorigin="anonymous" />
+    {{ if .opts.CfTurnstileEnabled }}
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    ></script>
+    {{ end }}
   </head>
 
   <body class="page-body">
@@ -38,6 +45,10 @@
           ></ul>
           <!-- prettier-ignore -->
           {{ template "input" InputOpts "confirm_password" "Confirm New Password" "password" "new-password" "Re-enter your new password to confirm" }}
+
+          {{ if .opts.CfTurnstileEnabled }}
+          {{ template "turnstile" .opts.CfTurnstileSiteKey }}
+          {{ end }}
 
           {{ template "form-submit" "Reset Password" }}
         </form>

--- a/internal/web/templates/templates.go
+++ b/internal/web/templates/templates.go
@@ -64,6 +64,9 @@ var rawSuccessMessage string
 //go:embed molecules/page-title.html
 var rawPageTitle string
 
+//go:embed molecules/turnstile.html
+var rawTurnstile string
+
 // HTML input types accepted by MakeInputOpts.
 const (
 	inputTypePassword = "password"
@@ -125,6 +128,7 @@ func parseCommonTemplates(tpl *template.Template) error {
 		rawFormSubmit,
 		rawSuccessMessage,
 		rawPageTitle,
+		rawTurnstile,
 	}
 
 	for _, tmpl := range templates {

--- a/internal/web/templates/templates_test.go
+++ b/internal/web/templates/templates_test.go
@@ -291,6 +291,58 @@ func TestRenderResetPassword(t *testing.T) {
 	}
 }
 
+func TestRenderTurnstileEnabledState(t *testing.T) {
+	tests := []struct {
+		name   string
+		render func(*options.Opts) ([]byte, error)
+	}{
+		{
+			name:   "index",
+			render: RenderIndex,
+		},
+		{
+			name:   "forgot-password",
+			render: RenderForgotPassword,
+		},
+		{
+			name:   "reset-password",
+			render: RenderResetPassword,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("disabled", func(t *testing.T) {
+				result, err := tt.render(&options.Opts{
+					CfTurnstileEnabled: false,
+					CfTurnstileSiteKey: "test-site-key",
+				})
+				require.NoError(t, err)
+
+				html := string(result)
+
+				assert.NotContains(t, html, `class="cf-turnstile"`)
+				assert.NotContains(t, html, `data-sitekey="test-site-key"`)
+				assert.NotContains(t, html, "https://challenges.cloudflare.com/turnstile/v0/api.js")
+			})
+
+			t.Run("enabled", func(t *testing.T) {
+				result, err := tt.render(&options.Opts{
+					CfTurnstileEnabled: true,
+					CfTurnstileSiteKey: "test-site-key",
+				})
+				require.NoError(t, err)
+
+				html := string(result)
+
+				assert.Contains(t, html, `class="cf-turnstile"`)
+				assert.Contains(t, html, `data-sitekey="test-site-key"`)
+				assert.Contains(t, html, "https://challenges.cloudflare.com/turnstile/v0/api.js")
+			})
+		})
+	}
+}
+
 // TestRenderIndexIdempotent tests that RenderIndex produces consistent output.
 func TestRenderIndexIdempotent(t *testing.T) {
 	opts := &options.Opts{

--- a/main.go
+++ b/main.go
@@ -48,6 +48,23 @@ const (
 		"form-action 'self'"
 )
 
+func buildContentSecurityPolicy(opts *options.Opts) string {
+	if !opts.CfTurnstileEnabled {
+		return contentSecurityPolicyHeader
+	}
+
+	return "default-src 'self'; " +
+		"script-src 'self' https://challenges.cloudflare.com; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data:; " +
+		"font-src 'self'; " +
+		"connect-src 'self' https://challenges.cloudflare.com; " +
+		"frame-src https://challenges.cloudflare.com; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'"
+}
+
 // healthCheckFlag is the CLI flag that triggers a standalone health-check run.
 const healthCheckFlag = "--health-check"
 
@@ -227,7 +244,7 @@ func buildApp(opts *options.Opts) (*fiber.App, error) {
 
 	// Security headers middleware
 	app.Use(helmet.New(helmet.Config{
-		ContentSecurityPolicy: contentSecurityPolicyHeader,
+		ContentSecurityPolicy: buildContentSecurityPolicy(opts),
 		XFrameOptions:         "DENY",
 		ContentTypeNosniff:    "nosniff",
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
@@ -378,6 +395,15 @@ func run(args []string) int {
 	if err != nil {
 		slog.Error("configuration error", "error", err)
 		return 1
+	}
+
+	if !opts.CfTurnstileEnabled &&
+		(opts.CfTurnstileSiteKey != "" || opts.CfTurnstileSecret != "") {
+		slog.Warn(
+			"turnstile_keys_configured_but_disabled",
+			"detail",
+			"Cloudflare Turnstile keys are configured but CF_TURNSTILE_ENABLED is false",
+		)
 	}
 
 	app, err := buildServerFunc(opts)

--- a/main_test.go
+++ b/main_test.go
@@ -429,6 +429,27 @@ func TestBuildApp(t *testing.T) {
 	assert.NotEmpty(t, resp.Header.Get("Content-Security-Policy"))
 }
 
+func TestBuildContentSecurityPolicyTurnstile(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		got := buildContentSecurityPolicy(&options.Opts{
+			CfTurnstileEnabled: false,
+		})
+
+		assert.Equal(t, contentSecurityPolicyHeader, got)
+		assert.NotContains(t, got, "https://challenges.cloudflare.com")
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		got := buildContentSecurityPolicy(&options.Opts{
+			CfTurnstileEnabled: true,
+		})
+
+		assert.Contains(t, got, "script-src 'self' https://challenges.cloudflare.com")
+		assert.Contains(t, got, "connect-src 'self' https://challenges.cloudflare.com")
+		assert.Contains(t, got, "frame-src https://challenges.cloudflare.com")
+	})
+}
+
 // TestBuildApp_BrandingOverlayIsServed exercises the overlay through the real
 // Fiber static middleware rather than through fs.FS directly: the middleware
 // decides what path it hands to Open, so serving an overridden asset is the


### PR DESCRIPTION
## Description

Adds optional Cloudflare Turnstile protection to the password change and password reset flows.

When configured, Turnstile is displayed on the change password, forgot password, and reset password forms. The generated token is verified server-side with Cloudflare before the corresponding RPC request is processed.

Turnstile remains disabled when no site key and secret are configured. Verification requests use a configurable timeout and fail closed if verification fails or Cloudflare cannot be reached.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [x] 🎨 UI/UX improvement
- [ ] ✅ Test coverage improvement

## Related Issues

N/A

## Changes Made

- Added optional Cloudflare Turnstile widgets to the change password, forgot password, and reset password forms.
- Added server-side Turnstile token verification before password-related RPC requests are processed.
- Added configuration for the Turnstile site key, secret, and verification timeout.
- Added CSP rules required for Cloudflare Turnstile when enabled.
- Turnstile remains completely disabled when not configured.

## Testing

### Test Environment

- OS: FreeBSD 15.1
- Go version: go version go1.26.6 freebsd/amd64
- Browser: Chromium-based browser

### Test Cases

- [ ] Unit tests pass (`go test ./...`)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Tested with different LDAP servers (if applicable):
  - [ ] Active Directory
  - [x] OpenLDAP
  - [ ] FreeIPA
  - [ ] Other:

### Test Results

Manually verified:

- Turnstile widget renders when configured.
- Password change succeeds with successful Turnstile verification.
- Forgot-password flow succeeds with successful Turnstile verification.
- Requests without a Turnstile token are rejected server-side.
- Direct RPC requests cannot bypass Turnstile verification.
- Turnstile is not rendered when it is not configured.

Example direct RPC request without a Turnstile token:

```sh
$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"change-password","params":["foo","bar","baz"]}'

{"success":false,"data":["Turnstile verification failed"]}

$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"request-password-reset","params":["foo","bar","baz"]}'

{"success":false,"data":["Turnstile verification failed"]}

$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"reset-password","params":["foo","bar","baz"]}'

{"success":false,"data":["Turnstile verification failed"]}

$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"change-password","params":["fake-reset-token","fake-new-password"]}'

{"success":false,"data":["Turnstile verification failed"]}

$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"request-password-reset","params":["fake-reset-token","fake-new-password"]}'

{"success":false,"data":["Turnstile verification failed"]}

$ curl -X POST https://pwd.example.com.com/api/rpc \
  -H 'Content-Type: application/json' \
  -d '{"method":"reset-password","params":["fake-reset-token","fake-new-password"]}'

{"success":false,"data":["Turnstile verification failed"]}
```
